### PR TITLE
Remove trailing whitespace from pintos src files

### DIFF
--- a/pintos/src/devices/block.c
+++ b/pintos/src/devices/block.c
@@ -210,7 +210,7 @@ block_register (const char *name, enum block_type type,
 
   return block;
 }
-
+
 /* Returns the block device corresponding to LIST_ELEM, or a null
    pointer if LIST_ELEM is the list end of all_blocks. */
 static struct block *

--- a/pintos/src/devices/block.h
+++ b/pintos/src/devices/block.h
@@ -17,7 +17,7 @@ typedef uint32_t block_sector_t;
 /* Format specifier for printf(), e.g.:
    printf ("sector=%"PRDSNu"\n", sector); */
 #define PRDSNu PRIu32
-
+
 /* Higher-level interface for file systems, etc. */
 
 struct block;
@@ -58,7 +58,7 @@ enum block_type block_type (struct block *);
 
 /* Statistics. */
 void block_print_stats (void);
-
+
 /* Lower-level interface to block device drivers. */
 
 struct block_operations

--- a/pintos/src/devices/ide.c
+++ b/pintos/src/devices/ide.c
@@ -99,7 +99,7 @@ static void interrupt_handler (struct intr_frame *);
 
 /* Initialize the disk subsystem and detect disks. */
 void
-ide_init (void) 
+ide_init (void)
 {
   size_t chan_no;
 
@@ -110,7 +110,7 @@ ide_init (void)
 
       /* Initialize channel. */
       snprintf (c->name, sizeof c->name, "ide%zu", chan_no);
-      switch (chan_no) 
+      switch (chan_no)
         {
         case 0:
           c->reg_base = 0x1f0;
@@ -126,13 +126,13 @@ ide_init (void)
       lock_init (&c->lock);
       c->expecting_interrupt = false;
       sema_init (&c->completion_wait, 0);
- 
+
       /* Initialize devices. */
       for (dev_no = 0; dev_no < 2; dev_no++)
         {
           struct ata_disk *d = &c->devices[dev_no];
           snprintf (d->name, sizeof d->name,
-                    "hd%c", 'a' + chan_no * 2 + dev_no); 
+                    "hd%c", 'a' + chan_no * 2 + dev_no);
           d->channel = c;
           d->dev_no = dev_no;
           d->is_ata = false;
@@ -154,7 +154,7 @@ ide_init (void)
           identify_ata_device (&c->devices[dev_no]);
     }
 }
-
+
 /* Disk detection and identification. */
 
 static char *descramble_ata_string (char *, int size);
@@ -162,7 +162,7 @@ static char *descramble_ata_string (char *, int size);
 /* Resets an ATA channel and waits for any devices present on it
    to finish the reset. */
 static void
-reset_channel (struct channel *c) 
+reset_channel (struct channel *c)
 {
   bool present[2];
   int dev_no;
@@ -199,10 +199,10 @@ reset_channel (struct channel *c)
   timer_msleep (150);
 
   /* Wait for device 0 to clear BSY. */
-  if (present[0]) 
+  if (present[0])
     {
       select_device (&c->devices[0]);
-      wait_while_busy (&c->devices[0]); 
+      wait_while_busy (&c->devices[0]);
     }
 
   /* Wait for device 1 to clear BSY. */
@@ -211,7 +211,7 @@ reset_channel (struct channel *c)
       int i;
 
       select_device (&c->devices[1]);
-      for (i = 0; i < 3000; i++) 
+      for (i = 0; i < 3000; i++)
         {
           if (inb (reg_nsect (c)) == 1 && inb (reg_lbal (c)) == 1)
             break;
@@ -227,7 +227,7 @@ reset_channel (struct channel *c)
    channel.  If D is device 1 (slave), the return value is not
    meaningful. */
 static bool
-check_device_type (struct ata_disk *d) 
+check_device_type (struct ata_disk *d)
 {
   struct channel *c = d->channel;
   uint8_t error, lbam, lbah, status;
@@ -244,12 +244,12 @@ check_device_type (struct ata_disk *d)
       || (status & STA_BSY) != 0)
     {
       d->is_ata = false;
-      return error != 0x81;      
+      return error != 0x81;
     }
-  else 
+  else
     {
       d->is_ata = (lbam == 0 && lbah == 0) || (lbam == 0x3c && lbah == 0xc3);
-      return true; 
+      return true;
     }
 }
 
@@ -257,7 +257,7 @@ check_device_type (struct ata_disk *d)
    response.  Registers the disk with the block device
    layer. */
 static void
-identify_ata_device (struct ata_disk *d) 
+identify_ata_device (struct ata_disk *d)
 {
   struct channel *c = d->channel;
   char id[BLOCK_SECTOR_SIZE];
@@ -313,7 +313,7 @@ identify_ata_device (struct ata_disk *d)
    format, into a null-terminated string in-place.  Drops
    trailing whitespace and null bytes.  Returns STRING.  */
 static char *
-descramble_ata_string (char *string, int size) 
+descramble_ata_string (char *string, int size)
 {
   int i;
 
@@ -330,13 +330,13 @@ descramble_ata_string (char *string, int size)
     {
       int c = string[size - 1];
       if (c != '\0' && !isspace (c))
-        break; 
+        break;
     }
   string[size] = '\0';
 
   return string;
 }
-
+
 /* Reads sector SEC_NO from disk D into BUFFER, which must have
    room for BLOCK_SECTOR_SIZE bytes.
    Internally synchronizes accesses to disks, so external
@@ -381,7 +381,7 @@ static struct block_operations ide_operations =
     ide_read,
     ide_write
   };
-
+
 /* Selects device D, waiting for it to become ready, and then
    writes SEC_NO to the disk's sector selection registers.  (We
    use LBA mode.) */
@@ -391,7 +391,7 @@ select_sector (struct ata_disk *d, block_sector_t sec_no)
   struct channel *c = d->channel;
 
   ASSERT (sec_no < (1UL << 28));
-  
+
   select_device_wait (d);
   outb (reg_nsect (c), 1);
   outb (reg_lbal (c), sec_no);
@@ -404,7 +404,7 @@ select_sector (struct ata_disk *d, block_sector_t sec_no)
 /* Writes COMMAND to channel C and prepares for receiving a
    completion interrupt. */
 static void
-issue_pio_command (struct channel *c, uint8_t command) 
+issue_pio_command (struct channel *c, uint8_t command)
 {
   /* Interrupts must be enabled or our semaphore will never be
      up'd by the completion handler. */
@@ -417,7 +417,7 @@ issue_pio_command (struct channel *c, uint8_t command)
 /* Reads a sector from channel C's data register in PIO mode into
    SECTOR, which must have room for BLOCK_SECTOR_SIZE bytes. */
 static void
-input_sector (struct channel *c, void *sector) 
+input_sector (struct channel *c, void *sector)
 {
   insw (reg_data (c), sector, BLOCK_SECTOR_SIZE / 2);
 }
@@ -425,11 +425,11 @@ input_sector (struct channel *c, void *sector)
 /* Writes SECTOR to channel C's data register in PIO mode.
    SECTOR must contain BLOCK_SECTOR_SIZE bytes. */
 static void
-output_sector (struct channel *c, const void *sector) 
+output_sector (struct channel *c, const void *sector)
 {
   outsw (reg_data (c), sector, BLOCK_SECTOR_SIZE / 2);
 }
-
+
 /* Low-level ATA primitives. */
 
 /* Wait up to 10 seconds for the controller to become idle, that
@@ -438,11 +438,11 @@ output_sector (struct channel *c, const void *sector)
    As a side effect, reading the status register clears any
    pending interrupt. */
 static void
-wait_until_idle (const struct ata_disk *d) 
+wait_until_idle (const struct ata_disk *d)
 {
   int i;
 
-  for (i = 0; i < 1000; i++) 
+  for (i = 0; i < 1000; i++)
     {
       if ((inb (reg_status (d->channel)) & (STA_BSY | STA_DRQ)) == 0)
         return;
@@ -457,16 +457,16 @@ wait_until_idle (const struct ata_disk *d)
    The ATA standards say that a disk may take as long as that to
    complete its reset. */
 static bool
-wait_while_busy (const struct ata_disk *d) 
+wait_while_busy (const struct ata_disk *d)
 {
   struct channel *c = d->channel;
   int i;
-  
+
   for (i = 0; i < 3000; i++)
     {
       if (i == 700)
         printf ("%s: busy, waiting...", d->name);
-      if (!(inb (reg_alt_status (c)) & STA_BSY)) 
+      if (!(inb (reg_alt_status (c)) & STA_BSY))
         {
           if (i >= 700)
             printf ("ok\n");
@@ -495,23 +495,23 @@ select_device (const struct ata_disk *d)
 /* Select disk D in its channel, as select_device(), but wait for
    the channel to become idle before and after. */
 static void
-select_device_wait (const struct ata_disk *d) 
+select_device_wait (const struct ata_disk *d)
 {
   wait_until_idle (d);
   select_device (d);
   wait_until_idle (d);
 }
-
+
 /* ATA interrupt handler. */
 static void
-interrupt_handler (struct intr_frame *f) 
+interrupt_handler (struct intr_frame *f)
 {
   struct channel *c;
 
   for (c = channels; c < channels + CHANNEL_CNT; c++)
     if (f->vec_no == c->irq)
       {
-        if (c->expecting_interrupt) 
+        if (c->expecting_interrupt)
           {
             inb (reg_status (c));               /* Acknowledge interrupt. */
             sema_up (&c->completion_wait);      /* Wake up waiter. */

--- a/pintos/src/devices/input.c
+++ b/pintos/src/devices/input.c
@@ -8,7 +8,7 @@ static struct intq buffer;
 
 /* Initializes the input buffer. */
 void
-input_init (void) 
+input_init (void)
 {
   intq_init (&buffer);
 }
@@ -16,7 +16,7 @@ input_init (void)
 /* Adds a key to the input buffer.
    Interrupts must be off and the buffer must not be full. */
 void
-input_putc (uint8_t key) 
+input_putc (uint8_t key)
 {
   ASSERT (intr_get_level () == INTR_OFF);
   ASSERT (!intq_full (&buffer));
@@ -28,7 +28,7 @@ input_putc (uint8_t key)
 /* Retrieves a key from the input buffer.
    If the buffer is empty, waits for a key to be pressed. */
 uint8_t
-input_getc (void) 
+input_getc (void)
 {
   enum intr_level old_level;
   uint8_t key;
@@ -37,7 +37,7 @@ input_getc (void)
   key = intq_getc (&buffer);
   serial_notify ();
   intr_set_level (old_level);
-  
+
   return key;
 }
 
@@ -45,7 +45,7 @@ input_getc (void)
    false otherwise.
    Interrupts must be off. */
 bool
-input_full (void) 
+input_full (void)
 {
   ASSERT (intr_get_level () == INTR_OFF);
   return intq_full (&buffer);

--- a/pintos/src/devices/intq.c
+++ b/pintos/src/devices/intq.c
@@ -8,7 +8,7 @@ static void signal (struct intq *q, struct thread **waiter);
 
 /* Initializes interrupt queue Q. */
 void
-intq_init (struct intq *q) 
+intq_init (struct intq *q)
 {
   lock_init (&q->lock);
   q->not_full = q->not_empty = NULL;
@@ -17,7 +17,7 @@ intq_init (struct intq *q)
 
 /* Returns true if Q is empty, false otherwise. */
 bool
-intq_empty (const struct intq *q) 
+intq_empty (const struct intq *q)
 {
   ASSERT (intr_get_level () == INTR_OFF);
   return q->head == q->tail;
@@ -25,7 +25,7 @@ intq_empty (const struct intq *q)
 
 /* Returns true if Q is full, false otherwise. */
 bool
-intq_full (const struct intq *q) 
+intq_full (const struct intq *q)
 {
   ASSERT (intr_get_level () == INTR_OFF);
   return next (q->head) == q->tail;
@@ -35,19 +35,19 @@ intq_full (const struct intq *q)
    If Q is empty, sleeps until a byte is added.
    When called from an interrupt handler, Q must not be empty. */
 uint8_t
-intq_getc (struct intq *q) 
+intq_getc (struct intq *q)
 {
   uint8_t byte;
-  
+
   ASSERT (intr_get_level () == INTR_OFF);
-  while (intq_empty (q)) 
+  while (intq_empty (q))
     {
       ASSERT (!intr_context ());
       lock_acquire (&q->lock);
       wait (q, &q->not_empty);
       lock_release (&q->lock);
     }
-  
+
   byte = q->buf[q->tail];
   q->tail = next (q->tail);
   signal (q, &q->not_full);
@@ -58,7 +58,7 @@ intq_getc (struct intq *q)
    If Q is full, sleeps until a byte is removed.
    When called from an interrupt handler, Q must not be full. */
 void
-intq_putc (struct intq *q, uint8_t byte) 
+intq_putc (struct intq *q, uint8_t byte)
 {
   ASSERT (intr_get_level () == INTR_OFF);
   while (intq_full (q))
@@ -73,10 +73,10 @@ intq_putc (struct intq *q, uint8_t byte)
   q->head = next (q->head);
   signal (q, &q->not_empty);
 }
-
+
 /* Returns the position after POS within an intq. */
 static int
-next (int pos) 
+next (int pos)
 {
   return (pos + 1) % INTQ_BUFSIZE;
 }
@@ -84,7 +84,7 @@ next (int pos)
 /* WAITER must be the address of Q's not_empty or not_full
    member.  Waits until the given condition is true. */
 static void
-wait (struct intq *q UNUSED, struct thread **waiter) 
+wait (struct intq *q UNUSED, struct thread **waiter)
 {
   ASSERT (!intr_context ());
   ASSERT (intr_get_level () == INTR_OFF);
@@ -100,13 +100,13 @@ wait (struct intq *q UNUSED, struct thread **waiter)
    thread is waiting for the condition, wakes it up and resets
    the waiting thread. */
 static void
-signal (struct intq *q UNUSED, struct thread **waiter) 
+signal (struct intq *q UNUSED, struct thread **waiter)
 {
   ASSERT (intr_get_level () == INTR_OFF);
   ASSERT ((waiter == &q->not_empty && !intq_empty (q))
           || (waiter == &q->not_full && !intq_full (q)));
 
-  if (*waiter != NULL) 
+  if (*waiter != NULL)
     {
       thread_unblock (*waiter);
       *waiter = NULL;

--- a/pintos/src/devices/timer.c
+++ b/pintos/src/devices/timer.c
@@ -7,7 +7,7 @@
 #include "threads/interrupt.h"
 #include "threads/synch.h"
 #include "threads/thread.h"
-  
+
 /* See [8254] for hardware details of the 8254 timer chip. */
 
 #if TIMER_FREQ < 19
@@ -33,7 +33,7 @@ static void real_time_delay (int64_t num, int32_t denom);
 /* Sets up the timer to interrupt TIMER_FREQ times per second,
    and registers the corresponding interrupt. */
 void
-timer_init (void) 
+timer_init (void)
 {
   pit_configure_channel (0, 2, TIMER_FREQ);
   intr_register_ext (0x20, timer_interrupt, "8254 Timer");
@@ -41,7 +41,7 @@ timer_init (void)
 
 /* Calibrates loops_per_tick, used to implement brief delays. */
 void
-timer_calibrate (void) 
+timer_calibrate (void)
 {
   unsigned high_bit, test_bit;
 
@@ -51,7 +51,7 @@ timer_calibrate (void)
   /* Approximate loops_per_tick as the largest power-of-two
      still less than one timer tick. */
   loops_per_tick = 1u << 10;
-  while (!too_many_loops (loops_per_tick << 1)) 
+  while (!too_many_loops (loops_per_tick << 1))
     {
       loops_per_tick <<= 1;
       ASSERT (loops_per_tick != 0);
@@ -68,7 +68,7 @@ timer_calibrate (void)
 
 /* Returns the number of timer ticks since the OS booted. */
 int64_t
-timer_ticks (void) 
+timer_ticks (void)
 {
   enum intr_level old_level = intr_disable ();
   int64_t t = ticks;
@@ -79,7 +79,7 @@ timer_ticks (void)
 /* Returns the number of timer ticks elapsed since THEN, which
    should be a value once returned by timer_ticks(). */
 int64_t
-timer_elapsed (int64_t then) 
+timer_elapsed (int64_t then)
 {
   return timer_ticks () - then;
 }
@@ -87,19 +87,19 @@ timer_elapsed (int64_t then)
 /* Sleeps for approximately TICKS timer ticks.  Interrupts must
    be turned on. */
 void
-timer_sleep (int64_t ticks) 
+timer_sleep (int64_t ticks)
 {
   int64_t start = timer_ticks ();
 
   ASSERT (intr_get_level () == INTR_ON);
-  while (timer_elapsed (start) < ticks) 
+  while (timer_elapsed (start) < ticks)
     thread_yield ();
 }
 
 /* Sleeps for approximately MS milliseconds.  Interrupts must be
    turned on. */
 void
-timer_msleep (int64_t ms) 
+timer_msleep (int64_t ms)
 {
   real_time_sleep (ms, 1000);
 }
@@ -107,7 +107,7 @@ timer_msleep (int64_t ms)
 /* Sleeps for approximately US microseconds.  Interrupts must be
    turned on. */
 void
-timer_usleep (int64_t us) 
+timer_usleep (int64_t us)
 {
   real_time_sleep (us, 1000 * 1000);
 }
@@ -115,7 +115,7 @@ timer_usleep (int64_t us)
 /* Sleeps for approximately NS nanoseconds.  Interrupts must be
    turned on. */
 void
-timer_nsleep (int64_t ns) 
+timer_nsleep (int64_t ns)
 {
   real_time_sleep (ns, 1000 * 1000 * 1000);
 }
@@ -128,7 +128,7 @@ timer_nsleep (int64_t ns)
    will cause timer ticks to be lost.  Thus, use timer_msleep()
    instead if interrupts are enabled. */
 void
-timer_mdelay (int64_t ms) 
+timer_mdelay (int64_t ms)
 {
   real_time_delay (ms, 1000);
 }
@@ -141,7 +141,7 @@ timer_mdelay (int64_t ms)
    will cause timer ticks to be lost.  Thus, use timer_usleep()
    instead if interrupts are enabled. */
 void
-timer_udelay (int64_t us) 
+timer_udelay (int64_t us)
 {
   real_time_delay (us, 1000 * 1000);
 }
@@ -154,18 +154,18 @@ timer_udelay (int64_t us)
    will cause timer ticks to be lost.  Thus, use timer_nsleep()
    instead if interrupts are enabled.*/
 void
-timer_ndelay (int64_t ns) 
+timer_ndelay (int64_t ns)
 {
   real_time_delay (ns, 1000 * 1000 * 1000);
 }
 
 /* Prints timer statistics. */
 void
-timer_print_stats (void) 
+timer_print_stats (void)
 {
   printf ("Timer: %"PRId64" ticks\n", timer_ticks ());
 }
-
+
 /* Timer interrupt handler. */
 static void
 timer_interrupt (struct intr_frame *args UNUSED)
@@ -177,7 +177,7 @@ timer_interrupt (struct intr_frame *args UNUSED)
 /* Returns true if LOOPS iterations waits for more than one timer
    tick, otherwise false. */
 static bool
-too_many_loops (unsigned loops) 
+too_many_loops (unsigned loops)
 {
   /* Wait for a timer tick. */
   int64_t start = ticks;
@@ -201,7 +201,7 @@ too_many_loops (unsigned loops)
    differently in different places the results would be difficult
    to predict. */
 static void NO_INLINE
-busy_wait (int64_t loops) 
+busy_wait (int64_t loops)
 {
   while (loops-- > 0)
     barrier ();
@@ -209,12 +209,12 @@ busy_wait (int64_t loops)
 
 /* Sleep for approximately NUM/DENOM seconds. */
 static void
-real_time_sleep (int64_t num, int32_t denom) 
+real_time_sleep (int64_t num, int32_t denom)
 {
   /* Convert NUM/DENOM seconds into timer ticks, rounding down.
-          
-        (NUM / DENOM) s          
-     ---------------------- = NUM * TIMER_FREQ / DENOM ticks. 
+
+        (NUM / DENOM) s
+     ---------------------- = NUM * TIMER_FREQ / DENOM ticks.
      1 s / TIMER_FREQ ticks
   */
   int64_t ticks = num * TIMER_FREQ / denom;
@@ -224,14 +224,14 @@ real_time_sleep (int64_t num, int32_t denom)
     {
       /* We're waiting for at least one full timer tick.  Use
          timer_sleep() because it will yield the CPU to other
-         processes. */                
-      timer_sleep (ticks); 
+         processes. */
+      timer_sleep (ticks);
     }
-  else 
+  else
     {
       /* Otherwise, use a busy-wait loop for more accurate
          sub-tick timing. */
-      real_time_delay (num, denom); 
+      real_time_delay (num, denom);
     }
 }
 
@@ -242,5 +242,5 @@ real_time_delay (int64_t num, int32_t denom)
   /* Scale the numerator and denominator down by 1000 to avoid
      the possibility of overflow. */
   ASSERT (denom % 1000 == 0);
-  busy_wait (loops_per_tick * num / 1000 * TIMER_FREQ / (denom / 1000)); 
+  busy_wait (loops_per_tick * num / 1000 * TIMER_FREQ / (denom / 1000));
 }

--- a/pintos/src/devices/vga.c
+++ b/pintos/src/devices/vga.c
@@ -42,7 +42,7 @@ init (void)
     {
       fb = ptov (0xb8000);
       find_cursor (&cx, &cy);
-      inited = true; 
+      inited = true;
     }
 }
 
@@ -56,8 +56,8 @@ vga_putc (int c)
   enum intr_level old_level = intr_disable ();
 
   init ();
-  
-  switch (c) 
+
+  switch (c)
     {
     case '\n':
       newline ();
@@ -71,7 +71,7 @@ vga_putc (int c)
       if (cx > 0)
         cx--;
       break;
-      
+
     case '\r':
       cx = 0;
       break;
@@ -87,7 +87,7 @@ vga_putc (int c)
       speaker_beep ();
       intr_disable ();
       break;
-      
+
     default:
       fb[cy][cx][0] = c;
       fb[cy][cx][1] = GRAY_ON_BLACK;
@@ -101,7 +101,7 @@ vga_putc (int c)
 
   intr_set_level (old_level);
 }
-
+
 /* Clears the screen and moves the cursor to the upper left. */
 static void
 cls (void)
@@ -117,7 +117,7 @@ cls (void)
 
 /* Clears row Y to spaces. */
 static void
-clear_row (size_t y) 
+clear_row (size_t y)
 {
   size_t x;
 
@@ -146,7 +146,7 @@ newline (void)
 
 /* Moves the hardware cursor to (cx,cy). */
 static void
-move_cursor (void) 
+move_cursor (void)
 {
   /* See [FREEVGA] under "Manipulating the Text-mode Cursor". */
   uint16_t cp = cx + COL_CNT * cy;
@@ -156,7 +156,7 @@ move_cursor (void)
 
 /* Reads the current hardware cursor position into (*X,*Y). */
 static void
-find_cursor (size_t *x, size_t *y) 
+find_cursor (size_t *x, size_t *y)
 {
   /* See [FREEVGA] under "Manipulating the Text-mode Cursor". */
   uint16_t cp;

--- a/pintos/src/examples/bubsort.c
+++ b/pintos/src/examples/bubsort.c
@@ -1,9 +1,9 @@
-/* sort.c 
+/* sort.c
 
    Test program to sort a large number of integers.
- 
+
    Intention is to stress virtual memory system.
- 
+
    Ideally, we could read the unsorted array off of the file
    system, and store the result back to the file system! */
 #include <stdio.h>

--- a/pintos/src/examples/cat.c
+++ b/pintos/src/examples/cat.c
@@ -6,21 +6,21 @@
 #include <syscall.h>
 
 int
-main (int argc, char *argv[]) 
+main (int argc, char *argv[])
 {
   bool success = true;
   int i;
-  
-  for (i = 1; i < argc; i++) 
+
+  for (i = 1; i < argc; i++)
     {
       int fd = open (argv[i]);
-      if (fd < 0) 
+      if (fd < 0)
         {
           printf ("%s: open failed\n", argv[i]);
           success = false;
           continue;
         }
-      for (;;) 
+      for (;;)
         {
           char buffer[1024];
           int bytes_read = read (fd, buffer, sizeof buffer);

--- a/pintos/src/examples/cmp.c
+++ b/pintos/src/examples/cmp.c
@@ -6,11 +6,11 @@
 #include <syscall.h>
 
 int
-main (int argc, char *argv[]) 
+main (int argc, char *argv[])
 {
   int fd[2];
 
-  if (argc != 3) 
+  if (argc != 3)
     {
       printf ("usage: cmp A B\n");
       return EXIT_FAILURE;
@@ -18,20 +18,20 @@ main (int argc, char *argv[])
 
   /* Open files. */
   fd[0] = open (argv[1]);
-  if (fd[0] < 0) 
+  if (fd[0] < 0)
     {
       printf ("%s: open failed\n", argv[1]);
       return EXIT_FAILURE;
     }
   fd[1] = open (argv[2]);
-  if (fd[1] < 0) 
+  if (fd[1] < 0)
     {
       printf ("%s: open failed\n", argv[1]);
       return EXIT_FAILURE;
     }
 
   /* Compare data. */
-  for (;;) 
+  for (;;)
     {
       int pos;
       char buffer[2][1024];
@@ -47,7 +47,7 @@ main (int argc, char *argv[])
         break;
 
       for (i = 0; i < min_read; i++)
-        if (buffer[0][i] != buffer[1][i]) 
+        if (buffer[0][i] != buffer[1][i])
           {
             printf ("Byte %d is %02hhx ('%c') in %s but %02hhx ('%c') in %s\n",
                     pos + i,

--- a/pintos/src/examples/cp.c
+++ b/pintos/src/examples/cp.c
@@ -6,11 +6,11 @@ Copies one file to another. */
 #include <syscall.h>
 
 int
-main (int argc, char *argv[]) 
+main (int argc, char *argv[])
 {
   int in_fd, out_fd;
 
-  if (argc != 3) 
+  if (argc != 3)
     {
       printf ("usage: cp OLD NEW\n");
       return EXIT_FAILURE;
@@ -18,33 +18,33 @@ main (int argc, char *argv[])
 
   /* Open input file. */
   in_fd = open (argv[1]);
-  if (in_fd < 0) 
+  if (in_fd < 0)
     {
       printf ("%s: open failed\n", argv[1]);
       return EXIT_FAILURE;
     }
 
   /* Create and open output file. */
-  if (!create (argv[2], filesize (in_fd))) 
+  if (!create (argv[2], filesize (in_fd)))
     {
       printf ("%s: create failed\n", argv[2]);
       return EXIT_FAILURE;
     }
   out_fd = open (argv[2]);
-  if (out_fd < 0) 
+  if (out_fd < 0)
     {
       printf ("%s: open failed\n", argv[2]);
       return EXIT_FAILURE;
     }
 
   /* Copy data. */
-  for (;;) 
+  for (;;)
     {
       char buffer[1024];
       int bytes_read = read (in_fd, buffer, sizeof buffer);
       if (bytes_read == 0)
         break;
-      if (write (out_fd, buffer, bytes_read) != bytes_read) 
+      if (write (out_fd, buffer, bytes_read) != bytes_read)
         {
           printf ("%s: write failed\n", argv[2]);
           return EXIT_FAILURE;

--- a/pintos/src/examples/halt.c
+++ b/pintos/src/examples/halt.c
@@ -1,7 +1,7 @@
 /* halt.c
 
    Simple program to test whether running a user program works.
- 	
+
    Just invokes a system call that shuts down the OS. */
 
 #include <syscall.h>

--- a/pintos/src/examples/hex-dump.c
+++ b/pintos/src/examples/hex-dump.c
@@ -6,21 +6,21 @@
 #include <syscall.h>
 
 int
-main (int argc, char *argv[]) 
+main (int argc, char *argv[])
 {
   bool success = true;
   int i;
-  
-  for (i = 1; i < argc; i++) 
+
+  for (i = 1; i < argc; i++)
     {
       int fd = open (argv[i]);
-      if (fd < 0) 
+      if (fd < 0)
         {
           printf ("%s: open failed\n", argv[i]);
           success = false;
           continue;
         }
-      for (;;) 
+      for (;;)
         {
           char buffer[1024];
           int pos = tell (fd);

--- a/pintos/src/examples/insult.c
+++ b/pintos/src/examples/insult.c
@@ -231,7 +231,7 @@ init_grammar (void)
   daGrammar[26] = bad_place;
   daGLoc[26] = bad_placeLoc;
 }
-
+
 #include <ctype.h>
 #include <debug.h>
 #include <random.h>
@@ -250,13 +250,13 @@ usage (int ret_code, const char *message, ...)
 {
   va_list args;
 
-  if (message != NULL) 
+  if (message != NULL)
     {
       va_start (args, message);
       vprintf (message, args);
       va_end (args);
     }
-  
+
   printf ("\n"
           "Usage: insult [OPTION]...\n"
           "Prints random insults to screen.\n\n"
@@ -273,7 +273,7 @@ main (int argc, char *argv[])
 {
   int sentence_cnt, new_seed, i, file_flag, sent_flag, seed_flag;
   int handle;
-  
+
   new_seed = 4951;
   sentence_cnt = 4;
   file_flag = 0;
@@ -337,7 +337,7 @@ main (int argc, char *argv[])
       expand (0, daGrammar, daGLoc, handle);
       hprintf (handle, "\n\n");
     }
-  
+
   if (file_flag)
     close (handle);
 

--- a/pintos/src/examples/lineup.c
+++ b/pintos/src/examples/lineup.c
@@ -24,7 +24,7 @@ main (int argc, char *argv[])
   if (handle < 0)
     exit (2);
 
-  for (;;) 
+  for (;;)
     {
       int n, i;
 

--- a/pintos/src/examples/ls.c
+++ b/pintos/src/examples/ls.c
@@ -1,5 +1,5 @@
 /* ls.c
-  
+
    Lists the contents of the directory or directories named on
    the command line, or of the current directory if none are
    named.
@@ -13,10 +13,10 @@
 #include <string.h>
 
 static bool
-list_dir (const char *dir, bool verbose) 
+list_dir (const char *dir, bool verbose)
 {
   int dir_fd = open (dir);
-  if (dir_fd == -1) 
+  if (dir_fd == -1)
     {
       printf ("%s: not found\n", dir);
       return false;
@@ -31,10 +31,10 @@ list_dir (const char *dir, bool verbose)
         printf (" (inumber %d)", inumber (dir_fd));
       printf (":\n");
 
-      while (readdir (dir_fd, name)) 
+      while (readdir (dir_fd, name))
         {
-          printf ("%s", name); 
-          if (verbose) 
+          printf ("%s", name);
+          if (verbose)
             {
               char full_name[128];
               int entry_fd;
@@ -58,28 +58,28 @@ list_dir (const char *dir, bool verbose)
           printf ("\n");
         }
     }
-  else 
+  else
     printf ("%s: not a directory\n", dir);
   close (dir_fd);
   return true;
 }
 
 int
-main (int argc, char *argv[]) 
+main (int argc, char *argv[])
 {
   bool success = true;
   bool verbose = false;
-  
-  if (argc > 1 && !strcmp (argv[1], "-l")) 
+
+  if (argc > 1 && !strcmp (argv[1], "-l"))
     {
       verbose = true;
       argv++;
       argc--;
     }
-  
+
   if (argc <= 1)
     success = list_dir (".", verbose);
-  else 
+  else
     {
       int i;
       for (i = 1; i < argc; i++)

--- a/pintos/src/examples/matmult.c
+++ b/pintos/src/examples/matmult.c
@@ -1,9 +1,9 @@
-/* matmult.c 
+/* matmult.c
 
    Test program to do matrix multiplication on large arrays.
- 
+
    Intended to stress virtual memory system.
-   
+
    Ideally, we could read the matrices off of the file system,
    and store the result back to the file system!
  */
@@ -47,7 +47,7 @@ main (void)
       }
 
   /* Multiply matrices. */
-  for (i = 0; i < DIM; i++)	
+  for (i = 0; i < DIM; i++)
     for (j = 0; j < DIM; j++)
       for (k = 0; k < DIM; k++)
 	C[i][j] += A[i][k] * B[k][j];

--- a/pintos/src/examples/mcat.c
+++ b/pintos/src/examples/mcat.c
@@ -7,11 +7,11 @@
 #include <syscall.h>
 
 int
-main (int argc, char *argv[]) 
+main (int argc, char *argv[])
 {
   int i;
-  
-  for (i = 1; i < argc; i++) 
+
+  for (i = 1; i < argc; i++)
     {
       int fd;
       mapid_t map;
@@ -20,7 +20,7 @@ main (int argc, char *argv[])
 
       /* Open input file. */
       fd = open (argv[i]);
-      if (fd < 0) 
+      if (fd < 0)
         {
           printf ("%s: open failed\n", argv[i]);
           return EXIT_FAILURE;
@@ -29,7 +29,7 @@ main (int argc, char *argv[])
 
       /* Map files. */
       map = mmap (fd, data);
-      if (map == MAP_FAILED) 
+      if (map == MAP_FAILED)
         {
           printf ("%s: mmap failed\n", argv[i]);
           return EXIT_FAILURE;

--- a/pintos/src/examples/mcp.c
+++ b/pintos/src/examples/mcp.c
@@ -7,7 +7,7 @@
 #include <syscall.h>
 
 int
-main (int argc, char *argv[]) 
+main (int argc, char *argv[])
 {
   int in_fd, out_fd;
   mapid_t in_map, out_map;
@@ -15,7 +15,7 @@ main (int argc, char *argv[])
   void *out_data = (void *) 0x20000000;
   int size;
 
-  if (argc != 3) 
+  if (argc != 3)
     {
       printf ("usage: cp OLD NEW\n");
       return EXIT_FAILURE;
@@ -23,7 +23,7 @@ main (int argc, char *argv[])
 
   /* Open input file. */
   in_fd = open (argv[1]);
-  if (in_fd < 0) 
+  if (in_fd < 0)
     {
       printf ("%s: open failed\n", argv[1]);
       return EXIT_FAILURE;
@@ -31,13 +31,13 @@ main (int argc, char *argv[])
   size = filesize (in_fd);
 
   /* Create and open output file. */
-  if (!create (argv[2], size)) 
+  if (!create (argv[2], size))
     {
       printf ("%s: create failed\n", argv[2]);
       return EXIT_FAILURE;
     }
   out_fd = open (argv[2]);
-  if (out_fd < 0) 
+  if (out_fd < 0)
     {
       printf ("%s: open failed\n", argv[2]);
       return EXIT_FAILURE;
@@ -45,7 +45,7 @@ main (int argc, char *argv[])
 
   /* Map files. */
   in_map = mmap (in_fd, in_data);
-  if (in_map == MAP_FAILED) 
+  if (in_map == MAP_FAILED)
     {
       printf ("%s: mmap failed\n", argv[1]);
       return EXIT_FAILURE;

--- a/pintos/src/examples/mkdir.c
+++ b/pintos/src/examples/mkdir.c
@@ -6,19 +6,19 @@
 #include <syscall.h>
 
 int
-main (int argc, char *argv[]) 
+main (int argc, char *argv[])
 {
-  if (argc != 2) 
+  if (argc != 2)
     {
       printf ("usage: %s DIRECTORY\n", argv[0]);
       return EXIT_FAILURE;
     }
 
-  if (!mkdir (argv[1])) 
+  if (!mkdir (argv[1]))
     {
       printf ("%s: mkdir failed\n", argv[1]);
       return EXIT_FAILURE;
     }
-  
+
   return EXIT_SUCCESS;
 }

--- a/pintos/src/examples/pwd.c
+++ b/pintos/src/examples/pwd.c
@@ -1,5 +1,5 @@
 /* pwd.c
-   
+
    Prints the absolute name of the present working directory. */
 
 #include <syscall.h>
@@ -10,29 +10,29 @@
 static bool getcwd (char *cwd, size_t cwd_size);
 
 int
-main (void) 
+main (void)
 {
   char cwd[128];
-  if (getcwd (cwd, sizeof cwd)) 
+  if (getcwd (cwd, sizeof cwd))
     {
       printf ("%s\n", cwd);
       return EXIT_SUCCESS;
     }
-  else 
+  else
     {
       printf ("error\n");
-      return EXIT_FAILURE; 
+      return EXIT_FAILURE;
     }
 }
-
+
 /* Stores the inode number for FILE_NAME in *INUM.
    Returns true if successful, false if the file could not be
    opened. */
 static bool
-get_inumber (const char *file_name, int *inum) 
+get_inumber (const char *file_name, int *inum)
 {
   int fd = open (file_name);
-  if (fd >= 0) 
+  if (fd >= 0)
     {
       *inum = inumber (fd);
       close (fd);
@@ -50,10 +50,10 @@ get_inumber (const char *file_name, int *inum)
    its space is accounted for.) */
 static bool
 prepend (const char *prefix,
-         char *dst, size_t *dst_len, size_t dst_size) 
+         char *dst, size_t *dst_len, size_t dst_size)
 {
   size_t prefix_len = strlen (prefix);
-  if (prefix_len + *dst_len + 1 <= dst_size) 
+  if (prefix_len + *dst_len + 1 <= dst_size)
     {
       *dst_len += prefix_len;
       memcpy ((dst + dst_size) - *dst_len, prefix, prefix_len);
@@ -69,10 +69,10 @@ prepend (const char *prefix,
    system errors, directory trees deeper than MAX_LEVEL levels,
    and insufficient space in CWD. */
 static bool
-getcwd (char *cwd, size_t cwd_size) 
+getcwd (char *cwd, size_t cwd_size)
 {
-  size_t cwd_len = 0;   
-  
+  size_t cwd_len = 0;
+
 #define MAX_LEVEL 20
   char name[MAX_LEVEL * 3 + 1 + READDIR_MAX_LEN + 1];
   char *namep;
@@ -116,10 +116,10 @@ getcwd (char *cwd, size_t cwd_size)
       for (;;)
         {
           int test_inum;
-          if (!readdir (parent_fd, namep) || !get_inumber (name, &test_inum)) 
+          if (!readdir (parent_fd, namep) || !get_inumber (name, &test_inum))
             {
               close (parent_fd);
-              return false; 
+              return false;
             }
           if (test_inum == child_inum)
             break;
@@ -135,18 +135,18 @@ getcwd (char *cwd, size_t cwd_size)
     }
 
   /* Finalize CWD. */
-  if (cwd_len > 0) 
+  if (cwd_len > 0)
     {
       /* Move the string to the beginning of CWD,
          and null-terminate it. */
       memmove (cwd, (cwd + cwd_size) - cwd_len, cwd_len);
       cwd[cwd_len] = '\0';
     }
-  else 
+  else
     {
       /* Special case for the root. */
-      strlcpy (cwd, "/", cwd_size); 
+      strlcpy (cwd, "/", cwd_size);
     }
-  
+
   return true;
 }

--- a/pintos/src/examples/recursor.c
+++ b/pintos/src/examples/recursor.c
@@ -9,7 +9,7 @@ main (int argc, char *argv[])
   pid_t pid;
   int retval = 0;
 
-  if (argc != 4) 
+  if (argc != 4)
     {
       printf ("usage: recursor <string> <depth> <waitp>\n");
       exit (1);
@@ -19,7 +19,7 @@ main (int argc, char *argv[])
   printf ("%s %s %s %s\n", argv[0], argv[1], argv[2], argv[3]);
 
   /* Execute child and wait for it to finish if requested. */
-  if (atoi (argv[2]) != 0) 
+  if (atoi (argv[2]) != 0)
     {
       snprintf (buffer, sizeof buffer,
                 "recursor %s %d %s", argv[1], atoi (argv[2]) - 1, argv[3]);
@@ -27,7 +27,7 @@ main (int argc, char *argv[])
       if (atoi (argv[3]))
         retval = wait (pid);
     }
-  
+
   /* Done. */
   printf ("%s %s: dying, retval=%d\n", argv[1], argv[2], retval);
   exit (retval);

--- a/pintos/src/examples/rm.c
+++ b/pintos/src/examples/rm.c
@@ -6,16 +6,16 @@
 #include <syscall.h>
 
 int
-main (int argc, char *argv[]) 
+main (int argc, char *argv[])
 {
   bool success = true;
   int i;
-  
+
   for (i = 1; i < argc; i++)
-    if (!remove (argv[i])) 
+    if (!remove (argv[i]))
       {
         printf ("%s: remove failed\n", argv[i]);
-        success = false; 
+        success = false;
       }
   return success ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/pintos/src/examples/shell.c
+++ b/pintos/src/examples/shell.c
@@ -10,23 +10,23 @@ int
 main (void)
 {
   printf ("Shell starting...\n");
-  for (;;) 
+  for (;;)
     {
       char command[80];
 
       /* Read command. */
       printf ("--");
       read_line (command, sizeof command);
-      
+
       /* Execute command. */
       if (!strcmp (command, "exit"))
         break;
-      else if (!memcmp (command, "cd ", 3)) 
+      else if (!memcmp (command, "cd ", 3))
         {
           if (!chdir (command + 3))
             printf ("\"%s\": chdir failed\n", command + 3);
         }
-      else if (command[0] == '\0') 
+      else if (command[0] == '\0')
         {
           /* Empty command. */
         }
@@ -49,7 +49,7 @@ main (void)
    expected by Unix users.  On return, LINE will always be
    null-terminated and will not end in a new-line character. */
 static void
-read_line (char line[], size_t size) 
+read_line (char line[], size_t size)
 {
   char *pos = line;
   for (;;)
@@ -57,7 +57,7 @@ read_line (char line[], size_t size)
       char c;
       read (STDIN_FILENO, &c, 1);
 
-      switch (c) 
+      switch (c)
         {
         case '\r':
           *pos = '\0';
@@ -75,7 +75,7 @@ read_line (char line[], size_t size)
 
         default:
           /* Add character to line. */
-          if (pos < line + size - 1) 
+          if (pos < line + size - 1)
             {
               putchar (c);
               *pos++ = c;
@@ -89,7 +89,7 @@ read_line (char line[], size_t size)
    position.  Returns true if successful, false if nothing was
    done. */
 static bool
-backspace (char **pos, char line[]) 
+backspace (char **pos, char line[])
 {
   if (*pos > line)
     {

--- a/pintos/src/filesys/directory.c
+++ b/pintos/src/filesys/directory.c
@@ -7,14 +7,14 @@
 #include "threads/malloc.h"
 
 /* A directory. */
-struct dir 
+struct dir
   {
     struct inode *inode;                /* Backing store. */
     off_t pos;                          /* Current position. */
   };
 
 /* A single directory entry. */
-struct dir_entry 
+struct dir_entry
   {
     block_sector_t inode_sector;        /* Sector number of header. */
     char name[NAME_MAX + 1];            /* Null terminated file name. */
@@ -32,7 +32,7 @@ dir_create (block_sector_t sector, size_t entry_cnt)
 /* Opens and returns the directory for the given INODE, of which
    it takes ownership.  Returns a null pointer on failure. */
 struct dir *
-dir_open (struct inode *inode) 
+dir_open (struct inode *inode)
 {
   struct dir *dir = calloc (1, sizeof *dir);
   if (inode != NULL && dir != NULL)
@@ -45,7 +45,7 @@ dir_open (struct inode *inode)
     {
       inode_close (inode);
       free (dir);
-      return NULL; 
+      return NULL;
     }
 }
 
@@ -60,14 +60,14 @@ dir_open_root (void)
 /* Opens and returns a new directory for the same inode as DIR.
    Returns a null pointer on failure. */
 struct dir *
-dir_reopen (struct dir *dir) 
+dir_reopen (struct dir *dir)
 {
   return dir_open (inode_reopen (dir->inode));
 }
 
 /* Destroys DIR and frees associated resources. */
 void
-dir_close (struct dir *dir) 
+dir_close (struct dir *dir)
 {
   if (dir != NULL)
     {
@@ -78,7 +78,7 @@ dir_close (struct dir *dir)
 
 /* Returns the inode encapsulated by DIR. */
 struct inode *
-dir_get_inode (struct dir *dir) 
+dir_get_inode (struct dir *dir)
 {
   return dir->inode;
 }
@@ -90,17 +90,17 @@ dir_get_inode (struct dir *dir)
    otherwise, returns false and ignores EP and OFSP. */
 static bool
 lookup (const struct dir *dir, const char *name,
-        struct dir_entry *ep, off_t *ofsp) 
+        struct dir_entry *ep, off_t *ofsp)
 {
   struct dir_entry e;
   size_t ofs;
-  
+
   ASSERT (dir != NULL);
   ASSERT (name != NULL);
 
   for (ofs = 0; inode_read_at (dir->inode, &e, sizeof e, ofs) == sizeof e;
-       ofs += sizeof e) 
-    if (e.in_use && !strcmp (name, e.name)) 
+       ofs += sizeof e)
+    if (e.in_use && !strcmp (name, e.name))
       {
         if (ep != NULL)
           *ep = e;
@@ -117,7 +117,7 @@ lookup (const struct dir *dir, const char *name,
    a null pointer.  The caller must close *INODE. */
 bool
 dir_lookup (const struct dir *dir, const char *name,
-            struct inode **inode) 
+            struct inode **inode)
 {
   struct dir_entry e;
 
@@ -159,12 +159,12 @@ dir_add (struct dir *dir, const char *name, block_sector_t inode_sector)
   /* Set OFS to offset of free slot.
      If there are no free slots, then it will be set to the
      current end-of-file.
-     
+
      inode_read_at() will only return a short read at end of file.
      Otherwise, we'd need to verify that we didn't get a short
      read due to something intermittent such as low memory. */
   for (ofs = 0; inode_read_at (dir->inode, &e, sizeof e, ofs) == sizeof e;
-       ofs += sizeof e) 
+       ofs += sizeof e)
     if (!e.in_use)
       break;
 
@@ -182,7 +182,7 @@ dir_add (struct dir *dir, const char *name, block_sector_t inode_sector)
    Returns true if successful, false on failure,
    which occurs only if there is no file with the given NAME. */
 bool
-dir_remove (struct dir *dir, const char *name) 
+dir_remove (struct dir *dir, const char *name)
 {
   struct dir_entry e;
   struct inode *inode = NULL;
@@ -203,7 +203,7 @@ dir_remove (struct dir *dir, const char *name)
 
   /* Erase directory entry. */
   e.in_use = false;
-  if (inode_write_at (dir->inode, &e, sizeof e, ofs) != sizeof e) 
+  if (inode_write_at (dir->inode, &e, sizeof e, ofs) != sizeof e)
     goto done;
 
   /* Remove inode. */
@@ -223,14 +223,14 @@ dir_readdir (struct dir *dir, char name[NAME_MAX + 1])
 {
   struct dir_entry e;
 
-  while (inode_read_at (dir->inode, &e, sizeof e, dir->pos) == sizeof e) 
+  while (inode_read_at (dir->inode, &e, sizeof e, dir->pos) == sizeof e)
     {
       dir->pos += sizeof e;
       if (e.in_use)
         {
           strlcpy (name, e.name, NAME_MAX + 1);
           return true;
-        } 
+        }
     }
   return false;
 }

--- a/pintos/src/filesys/file.c
+++ b/pintos/src/filesys/file.c
@@ -4,7 +4,7 @@
 #include "threads/malloc.h"
 
 /* An open file. */
-struct file 
+struct file
   {
     struct inode *inode;        /* File's inode. */
     off_t pos;                  /* Current position. */
@@ -15,7 +15,7 @@ struct file
    and returns the new file.  Returns a null pointer if an
    allocation fails or if INODE is null. */
 struct file *
-file_open (struct inode *inode) 
+file_open (struct inode *inode)
 {
   struct file *file = calloc (1, sizeof *file);
   if (inode != NULL && file != NULL)
@@ -29,33 +29,33 @@ file_open (struct inode *inode)
     {
       inode_close (inode);
       free (file);
-      return NULL; 
+      return NULL;
     }
 }
 
 /* Opens and returns a new file for the same inode as FILE.
    Returns a null pointer if unsuccessful. */
 struct file *
-file_reopen (struct file *file) 
+file_reopen (struct file *file)
 {
   return file_open (inode_reopen (file->inode));
 }
 
 /* Closes FILE. */
 void
-file_close (struct file *file) 
+file_close (struct file *file)
 {
   if (file != NULL)
     {
       file_allow_write (file);
       inode_close (file->inode);
-      free (file); 
+      free (file);
     }
 }
 
 /* Returns the inode encapsulated by FILE. */
 struct inode *
-file_get_inode (struct file *file) 
+file_get_inode (struct file *file)
 {
   return file->inode;
 }
@@ -66,7 +66,7 @@ file_get_inode (struct file *file)
    which may be less than SIZE if end of file is reached.
    Advances FILE's position by the number of bytes read. */
 off_t
-file_read (struct file *file, void *buffer, off_t size) 
+file_read (struct file *file, void *buffer, off_t size)
 {
   off_t bytes_read = inode_read_at (file->inode, buffer, size, file->pos);
   file->pos += bytes_read;
@@ -79,7 +79,7 @@ file_read (struct file *file, void *buffer, off_t size)
    which may be less than SIZE if end of file is reached.
    The file's current position is unaffected. */
 off_t
-file_read_at (struct file *file, void *buffer, off_t size, off_t file_ofs) 
+file_read_at (struct file *file, void *buffer, off_t size, off_t file_ofs)
 {
   return inode_read_at (file->inode, buffer, size, file_ofs);
 }
@@ -92,7 +92,7 @@ file_read_at (struct file *file, void *buffer, off_t size, off_t file_ofs)
    not yet implemented.)
    Advances FILE's position by the number of bytes read. */
 off_t
-file_write (struct file *file, const void *buffer, off_t size) 
+file_write (struct file *file, const void *buffer, off_t size)
 {
   off_t bytes_written = inode_write_at (file->inode, buffer, size, file->pos);
   file->pos += bytes_written;
@@ -108,7 +108,7 @@ file_write (struct file *file, const void *buffer, off_t size)
    The file's current position is unaffected. */
 off_t
 file_write_at (struct file *file, const void *buffer, off_t size,
-               off_t file_ofs) 
+               off_t file_ofs)
 {
   return inode_write_at (file->inode, buffer, size, file_ofs);
 }
@@ -116,10 +116,10 @@ file_write_at (struct file *file, const void *buffer, off_t size,
 /* Prevents write operations on FILE's underlying inode
    until file_allow_write() is called or FILE is closed. */
 void
-file_deny_write (struct file *file) 
+file_deny_write (struct file *file)
 {
   ASSERT (file != NULL);
-  if (!file->deny_write) 
+  if (!file->deny_write)
     {
       file->deny_write = true;
       inode_deny_write (file->inode);
@@ -130,10 +130,10 @@ file_deny_write (struct file *file)
    (Writes might still be denied by some other file that has the
    same inode open.) */
 void
-file_allow_write (struct file *file) 
+file_allow_write (struct file *file)
 {
   ASSERT (file != NULL);
-  if (file->deny_write) 
+  if (file->deny_write)
     {
       file->deny_write = false;
       inode_allow_write (file->inode);
@@ -142,7 +142,7 @@ file_allow_write (struct file *file)
 
 /* Returns the size of FILE in bytes. */
 off_t
-file_length (struct file *file) 
+file_length (struct file *file)
 {
   ASSERT (file != NULL);
   return inode_length (file->inode);
@@ -161,7 +161,7 @@ file_seek (struct file *file, off_t new_pos)
 /* Returns the current position in FILE as a byte offset from the
    start of the file. */
 off_t
-file_tell (struct file *file) 
+file_tell (struct file *file)
 {
   ASSERT (file != NULL);
   return file->pos;

--- a/pintos/src/filesys/filesys.c
+++ b/pintos/src/filesys/filesys.c
@@ -15,7 +15,7 @@ static void do_format (void);
 /* Initializes the file system module.
    If FORMAT is true, reformats the file system. */
 void
-filesys_init (bool format) 
+filesys_init (bool format)
 {
   fs_device = block_get_role (BLOCK_FILESYS);
   if (fs_device == NULL)
@@ -24,7 +24,7 @@ filesys_init (bool format)
   inode_init ();
   free_map_init ();
 
-  if (format) 
+  if (format)
     do_format ();
 
   free_map_open ();
@@ -33,17 +33,17 @@ filesys_init (bool format)
 /* Shuts down the file system module, writing any unwritten data
    to disk. */
 void
-filesys_done (void) 
+filesys_done (void)
 {
   free_map_close ();
 }
-
+
 /* Creates a file named NAME with the given INITIAL_SIZE.
    Returns true if successful, false otherwise.
    Fails if a file named NAME already exists,
    or if internal memory allocation fails. */
 bool
-filesys_create (const char *name, off_t initial_size) 
+filesys_create (const char *name, off_t initial_size)
 {
   block_sector_t inode_sector = 0;
   struct dir *dir = dir_open_root ();
@@ -51,7 +51,7 @@ filesys_create (const char *name, off_t initial_size)
                   && free_map_allocate (1, &inode_sector)
                   && inode_create (inode_sector, initial_size)
                   && dir_add (dir, name, inode_sector));
-  if (!success && inode_sector != 0) 
+  if (!success && inode_sector != 0)
     free_map_release (inode_sector, 1);
   dir_close (dir);
 
@@ -81,15 +81,15 @@ filesys_open (const char *name)
    Fails if no file named NAME exists,
    or if an internal memory allocation fails. */
 bool
-filesys_remove (const char *name) 
+filesys_remove (const char *name)
 {
   struct dir *dir = dir_open_root ();
   bool success = dir != NULL && dir_remove (dir, name);
-  dir_close (dir); 
+  dir_close (dir);
 
   return success;
 }
-
+
 /* Formats the file system. */
 static void
 do_format (void)

--- a/pintos/src/filesys/free-map.c
+++ b/pintos/src/filesys/free-map.c
@@ -10,7 +10,7 @@ static struct bitmap *free_map;      /* Free map, one bit per sector. */
 
 /* Initializes the free map. */
 void
-free_map_init (void) 
+free_map_init (void)
 {
   free_map = bitmap_create (block_size (fs_device));
   if (free_map == NULL)
@@ -32,7 +32,7 @@ free_map_allocate (size_t cnt, block_sector_t *sectorp)
       && free_map_file != NULL
       && !bitmap_write (free_map, free_map_file))
     {
-      bitmap_set_multiple (free_map, sector, cnt, false); 
+      bitmap_set_multiple (free_map, sector, cnt, false);
       sector = BITMAP_ERROR;
     }
   if (sector != BITMAP_ERROR)
@@ -51,7 +51,7 @@ free_map_release (block_sector_t sector, size_t cnt)
 
 /* Opens the free map file and reads it from disk. */
 void
-free_map_open (void) 
+free_map_open (void)
 {
   free_map_file = file_open (inode_open (FREE_MAP_SECTOR));
   if (free_map_file == NULL)
@@ -62,7 +62,7 @@ free_map_open (void)
 
 /* Writes the free map to disk and closes the free map file. */
 void
-free_map_close (void) 
+free_map_close (void)
 {
   file_close (free_map_file);
 }
@@ -70,7 +70,7 @@ free_map_close (void)
 /* Creates a new free map file on disk and writes the free map to
    it. */
 void
-free_map_create (void) 
+free_map_create (void)
 {
   /* Create inode. */
   if (!inode_create (FREE_MAP_SECTOR, bitmap_file_size (free_map)))

--- a/pintos/src/filesys/fsutil.c
+++ b/pintos/src/filesys/fsutil.c
@@ -13,11 +13,11 @@
 
 /* List files in the root directory. */
 void
-fsutil_ls (char **argv UNUSED) 
+fsutil_ls (char **argv UNUSED)
 {
   struct dir *dir;
   char name[NAME_MAX + 1];
-  
+
   printf ("Files in the root directory:\n");
   dir = dir_open_root ();
   if (dir == NULL)
@@ -33,7 +33,7 @@ void
 fsutil_cat (char **argv)
 {
   const char *file_name = argv[1];
-  
+
   struct file *file;
   char *buffer;
 
@@ -42,14 +42,14 @@ fsutil_cat (char **argv)
   if (file == NULL)
     PANIC ("%s: open failed", file_name);
   buffer = palloc_get_page (PAL_ASSERT);
-  for (;;) 
+  for (;;)
     {
       off_t pos = file_tell (file);
       off_t n = file_read (file, buffer, PGSIZE);
       if (n == 0)
         break;
 
-      hex_dump (pos, buffer, n, true); 
+      hex_dump (pos, buffer, n, true);
     }
   palloc_free_page (buffer);
   file_close (file);
@@ -57,10 +57,10 @@ fsutil_cat (char **argv)
 
 /* Deletes file ARGV[1]. */
 void
-fsutil_rm (char **argv) 
+fsutil_rm (char **argv)
 {
   const char *file_name = argv[1];
-  
+
   printf ("Deleting '%s'...\n", file_name);
   if (!filesys_remove (file_name))
     PANIC ("%s: delete failed\n", file_name);
@@ -69,7 +69,7 @@ fsutil_rm (char **argv)
 /* Extracts a ustar-format tar archive from the scratch block
    device into the Pintos file system. */
 void
-fsutil_extract (char **argv UNUSED) 
+fsutil_extract (char **argv UNUSED)
 {
   static block_sector_t sector = 0;
 
@@ -190,14 +190,14 @@ fsutil_append (char **argv)
   dst = block_get_role (BLOCK_SCRATCH);
   if (dst == NULL)
     PANIC ("couldn't open scratch device");
-  
+
   /* Write ustar header to first sector. */
   if (!ustar_make_header (file_name, USTAR_REGULAR, size, buffer))
     PANIC ("%s: name too long for ustar format", file_name);
   block_write (dst, sector++, buffer);
 
   /* Do copy. */
-  while (size > 0) 
+  while (size > 0)
     {
       int chunk_size = size > BLOCK_SECTOR_SIZE ? BLOCK_SECTOR_SIZE : size;
       if (sector >= block_size (dst))

--- a/pintos/src/filesys/inode.c
+++ b/pintos/src/filesys/inode.c
@@ -29,7 +29,7 @@ bytes_to_sectors (off_t size)
 }
 
 /* In-memory inode. */
-struct inode 
+struct inode
   {
     struct list_elem elem;              /* Element in inode list. */
     block_sector_t sector;              /* Sector number of disk location. */
@@ -44,7 +44,7 @@ struct inode
    Returns -1 if INODE does not contain data for a byte at offset
    POS. */
 static block_sector_t
-byte_to_sector (const struct inode *inode, off_t pos) 
+byte_to_sector (const struct inode *inode, off_t pos)
 {
   ASSERT (inode != NULL);
   if (pos < inode->data.length)
@@ -59,7 +59,7 @@ static struct list open_inodes;
 
 /* Initializes the inode module. */
 void
-inode_init (void) 
+inode_init (void)
 {
   list_init (&open_inodes);
 }
@@ -87,19 +87,19 @@ inode_create (block_sector_t sector, off_t length)
       size_t sectors = bytes_to_sectors (length);
       disk_inode->length = length;
       disk_inode->magic = INODE_MAGIC;
-      if (free_map_allocate (sectors, &disk_inode->start)) 
+      if (free_map_allocate (sectors, &disk_inode->start))
         {
           block_write (fs_device, sector, disk_inode);
-          if (sectors > 0) 
+          if (sectors > 0)
             {
               static char zeros[BLOCK_SECTOR_SIZE];
               size_t i;
-              
-              for (i = 0; i < sectors; i++) 
+
+              for (i = 0; i < sectors; i++)
                 block_write (fs_device, disk_inode->start + i, zeros);
             }
-          success = true; 
-        } 
+          success = true;
+        }
       free (disk_inode);
     }
   return success;
@@ -116,13 +116,13 @@ inode_open (block_sector_t sector)
 
   /* Check whether this inode is already open. */
   for (e = list_begin (&open_inodes); e != list_end (&open_inodes);
-       e = list_next (e)) 
+       e = list_next (e))
     {
       inode = list_entry (e, struct inode, elem);
-      if (inode->sector == sector) 
+      if (inode->sector == sector)
         {
           inode_reopen (inode);
-          return inode; 
+          return inode;
         }
     }
 
@@ -161,7 +161,7 @@ inode_get_inumber (const struct inode *inode)
    If this was the last reference to INODE, frees its memory.
    If INODE was also a removed inode, frees its blocks. */
 void
-inode_close (struct inode *inode) 
+inode_close (struct inode *inode)
 {
   /* Ignore null pointer. */
   if (inode == NULL)
@@ -172,23 +172,23 @@ inode_close (struct inode *inode)
     {
       /* Remove from inode list and release lock. */
       list_remove (&inode->elem);
- 
+
       /* Deallocate blocks if removed. */
-      if (inode->removed) 
+      if (inode->removed)
         {
           free_map_release (inode->sector, 1);
           free_map_release (inode->data.start,
-                            bytes_to_sectors (inode->data.length)); 
+                            bytes_to_sectors (inode->data.length));
         }
 
-      free (inode); 
+      free (inode);
     }
 }
 
 /* Marks INODE to be deleted when it is closed by the last caller who
    has it open. */
 void
-inode_remove (struct inode *inode) 
+inode_remove (struct inode *inode)
 {
   ASSERT (inode != NULL);
   inode->removed = true;
@@ -198,13 +198,13 @@ inode_remove (struct inode *inode)
    Returns the number of bytes actually read, which may be less
    than SIZE if an error occurs or end of file is reached. */
 off_t
-inode_read_at (struct inode *inode, void *buffer_, off_t size, off_t offset) 
+inode_read_at (struct inode *inode, void *buffer_, off_t size, off_t offset)
 {
   uint8_t *buffer = buffer_;
   off_t bytes_read = 0;
   uint8_t *bounce = NULL;
 
-  while (size > 0) 
+  while (size > 0)
     {
       /* Disk sector to read, starting byte offset within sector. */
       block_sector_t sector_idx = byte_to_sector (inode, offset);
@@ -225,11 +225,11 @@ inode_read_at (struct inode *inode, void *buffer_, off_t size, off_t offset)
           /* Read full sector directly into caller's buffer. */
           block_read (fs_device, sector_idx, buffer + bytes_read);
         }
-      else 
+      else
         {
           /* Read sector into bounce buffer, then partially copy
              into caller's buffer. */
-          if (bounce == NULL) 
+          if (bounce == NULL)
             {
               bounce = malloc (BLOCK_SECTOR_SIZE);
               if (bounce == NULL)
@@ -238,7 +238,7 @@ inode_read_at (struct inode *inode, void *buffer_, off_t size, off_t offset)
           block_read (fs_device, sector_idx, bounce);
           memcpy (buffer + bytes_read, bounce + sector_ofs, chunk_size);
         }
-      
+
       /* Advance. */
       size -= chunk_size;
       offset += chunk_size;
@@ -256,7 +256,7 @@ inode_read_at (struct inode *inode, void *buffer_, off_t size, off_t offset)
    growth is not yet implemented.) */
 off_t
 inode_write_at (struct inode *inode, const void *buffer_, off_t size,
-                off_t offset) 
+                off_t offset)
 {
   const uint8_t *buffer = buffer_;
   off_t bytes_written = 0;
@@ -265,7 +265,7 @@ inode_write_at (struct inode *inode, const void *buffer_, off_t size,
   if (inode->deny_write_cnt)
     return 0;
 
-  while (size > 0) 
+  while (size > 0)
     {
       /* Sector to write, starting byte offset within sector. */
       block_sector_t sector_idx = byte_to_sector (inode, offset);
@@ -286,10 +286,10 @@ inode_write_at (struct inode *inode, const void *buffer_, off_t size,
           /* Write full sector directly to disk. */
           block_write (fs_device, sector_idx, buffer + bytes_written);
         }
-      else 
+      else
         {
           /* We need a bounce buffer. */
-          if (bounce == NULL) 
+          if (bounce == NULL)
             {
               bounce = malloc (BLOCK_SECTOR_SIZE);
               if (bounce == NULL)
@@ -299,7 +299,7 @@ inode_write_at (struct inode *inode, const void *buffer_, off_t size,
           /* If the sector contains data before or after the chunk
              we're writing, then we need to read in the sector
              first.  Otherwise we start with a sector of all zeros. */
-          if (sector_ofs > 0 || chunk_size < sector_left) 
+          if (sector_ofs > 0 || chunk_size < sector_left)
             block_read (fs_device, sector_idx, bounce);
           else
             memset (bounce, 0, BLOCK_SECTOR_SIZE);
@@ -320,7 +320,7 @@ inode_write_at (struct inode *inode, const void *buffer_, off_t size,
 /* Disables writes to INODE.
    May be called at most once per inode opener. */
 void
-inode_deny_write (struct inode *inode) 
+inode_deny_write (struct inode *inode)
 {
   inode->deny_write_cnt++;
   ASSERT (inode->deny_write_cnt <= inode->open_cnt);
@@ -330,7 +330,7 @@ inode_deny_write (struct inode *inode)
    Must be called once by each inode opener who has called
    inode_deny_write() on the inode, before closing the inode. */
 void
-inode_allow_write (struct inode *inode) 
+inode_allow_write (struct inode *inode)
 {
   ASSERT (inode->deny_write_cnt > 0);
   ASSERT (inode->deny_write_cnt <= inode->open_cnt);

--- a/pintos/src/lib/arithmetic.c
+++ b/pintos/src/lib/arithmetic.c
@@ -39,7 +39,7 @@ divl (uint64_t n, uint32_t d)
 /* Returns the number of leading zero bits in X,
    which must be nonzero. */
 static int
-nlz (uint32_t x) 
+nlz (uint32_t x)
 {
   /* This technique is portable, but there are better ways to do
      it on particular systems.  With sufficiently new enough GCC,
@@ -50,12 +50,12 @@ nlz (uint32_t x)
   if (x <= 0x0000FFFF)
     {
       n += 16;
-      x <<= 16; 
+      x <<= 16;
     }
   if (x <= 0x00FFFFFF)
     {
       n += 8;
-      x <<= 8; 
+      x <<= 8;
     }
   if (x <= 0x0FFFFFFF)
     {
@@ -65,7 +65,7 @@ nlz (uint32_t x)
   if (x <= 0x3FFFFFFF)
     {
       n += 2;
-      x <<= 2; 
+      x <<= 2;
     }
   if (x <= 0x7FFFFFFF)
     n++;
@@ -77,7 +77,7 @@ nlz (uint32_t x)
 static uint64_t
 udiv64 (uint64_t n, uint64_t d)
 {
-  if ((d >> 32) == 0) 
+  if ((d >> 32) == 0)
     {
       /* Proof of correctness:
 
@@ -105,23 +105,23 @@ udiv64 (uint64_t n, uint64_t d)
          Therefore, this code is correct and will not trap. */
       uint64_t b = 1ULL << 32;
       uint32_t n1 = n >> 32;
-      uint32_t n0 = n; 
+      uint32_t n0 = n;
       uint32_t d0 = d;
 
-      return divl (b * (n1 % d0) + n0, d0) + b * (n1 / d0); 
+      return divl (b * (n1 % d0) + n0, d0) + b * (n1 / d0);
     }
-  else 
+  else
     {
       /* Based on the algorithm and proof available from
          http://www.hackersdelight.org/revisions.pdf. */
       if (n < d)
         return 0;
-      else 
+      else
         {
           uint32_t d1 = d >> 32;
           int s = nlz (d1);
           uint64_t q = divl (n >> 1, (d << s) >> 32) >> (31 - s);
-          return n - (q - 1) * d < d ? q - 1 : q; 
+          return n - (q - 1) * d < d ? q - 1 : q;
         }
     }
 }
@@ -152,7 +152,7 @@ smod64 (int64_t n, int64_t d)
 {
   return n - d * sdiv64 (n, d);
 }
-
+
 /* These are the routines that GCC calls. */
 
 long long __divdi3 (long long n, long long d);
@@ -162,28 +162,28 @@ unsigned long long __umoddi3 (unsigned long long n, unsigned long long d);
 
 /* Signed 64-bit division. */
 long long
-__divdi3 (long long n, long long d) 
+__divdi3 (long long n, long long d)
 {
   return sdiv64 (n, d);
 }
 
 /* Signed 64-bit remainder. */
 long long
-__moddi3 (long long n, long long d) 
+__moddi3 (long long n, long long d)
 {
   return smod64 (n, d);
 }
 
 /* Unsigned 64-bit division. */
 unsigned long long
-__udivdi3 (unsigned long long n, unsigned long long d) 
+__udivdi3 (unsigned long long n, unsigned long long d)
 {
   return udiv64 (n, d);
 }
 
 /* Unsigned 64-bit remainder. */
 unsigned long long
-__umoddi3 (unsigned long long n, unsigned long long d) 
+__umoddi3 (unsigned long long n, unsigned long long d)
 {
   return umod64 (n, d);
 }

--- a/pintos/src/lib/debug.c
+++ b/pintos/src/lib/debug.c
@@ -10,19 +10,19 @@
    may be applied to kernel.o to translate these into file names,
    line numbers, and function names.  */
 void
-debug_backtrace (void) 
+debug_backtrace (void)
 {
   static bool explained;
   void **frame;
-  
+
   printf ("Call stack: %p", __builtin_return_address (0));
   for (frame = __builtin_frame_address (1);
        (uintptr_t) frame >= 0x1000 && frame[0] != NULL;
-       frame = frame[0]) 
+       frame = frame[0])
     printf (" %p", frame[1]);
   printf (".\n");
 
-  if (!explained) 
+  if (!explained)
     {
       explained = true;
       printf ("The `backtrace' program can make call stacks useful.\n"

--- a/pintos/src/lib/kernel/bitmap.c
+++ b/pintos/src/lib/kernel/bitmap.c
@@ -7,7 +7,7 @@
 #ifdef FILESYS
 #include "filesys/file.h"
 #endif
-
+
 /* Element type.
 
    This must be an unsigned integer type at least as wide as int.
@@ -33,7 +33,7 @@ struct bitmap
 /* Returns the index of the element that contains the bit
    numbered BIT_IDX. */
 static inline size_t
-elem_idx (size_t bit_idx) 
+elem_idx (size_t bit_idx)
 {
   return bit_idx / ELEM_BITS;
 }
@@ -41,7 +41,7 @@ elem_idx (size_t bit_idx)
 /* Returns an elem_type where only the bit corresponding to
    BIT_IDX is turned on. */
 static inline elem_type
-bit_mask (size_t bit_idx) 
+bit_mask (size_t bit_idx)
 {
   return (elem_type) 1 << (bit_idx % ELEM_BITS);
 }
@@ -63,12 +63,12 @@ byte_cnt (size_t bit_cnt)
 /* Returns a bit mask in which the bits actually used in the last
    element of B's bits are set to 1 and the rest are set to 0. */
 static inline elem_type
-last_mask (const struct bitmap *b) 
+last_mask (const struct bitmap *b)
 {
   int last_bits = b->bit_cnt % ELEM_BITS;
   return last_bits ? ((elem_type) 1 << last_bits) - 1 : (elem_type) -1;
 }
-
+
 /* Creation and destruction. */
 
 /* Creates and returns a pointer to a newly allocated bitmap with room for
@@ -76,7 +76,7 @@ last_mask (const struct bitmap *b)
    The caller is responsible for freeing the bitmap, with bitmap_destroy(),
    when it is no longer needed. */
 struct bitmap *
-bitmap_create (size_t bit_cnt) 
+bitmap_create (size_t bit_cnt)
 {
   struct bitmap *b = malloc (sizeof *b);
   if (b != NULL)
@@ -100,7 +100,7 @@ struct bitmap *
 bitmap_create_in_buf (size_t bit_cnt, void *block, size_t block_size UNUSED)
 {
   struct bitmap *b = block;
-  
+
   ASSERT (block_size >= bitmap_buf_size (bit_cnt));
 
   b->bit_cnt = bit_cnt;
@@ -112,7 +112,7 @@ bitmap_create_in_buf (size_t bit_cnt, void *block, size_t block_size UNUSED)
 /* Returns the number of bytes required to accomodate a bitmap
    with BIT_CNT bits (for use with bitmap_create_in_buf()). */
 size_t
-bitmap_buf_size (size_t bit_cnt) 
+bitmap_buf_size (size_t bit_cnt)
 {
   return sizeof (struct bitmap) + byte_cnt (bit_cnt);
 }
@@ -120,15 +120,15 @@ bitmap_buf_size (size_t bit_cnt)
 /* Destroys bitmap B, freeing its storage.
    Not for use on bitmaps created by bitmap_create_in_buf(). */
 void
-bitmap_destroy (struct bitmap *b) 
+bitmap_destroy (struct bitmap *b)
 {
-  if (b != NULL) 
+  if (b != NULL)
     {
       free (b->bits);
       free (b);
     }
 }
-
+
 /* Bitmap size. */
 
 /* Returns the number of bits in B. */
@@ -137,12 +137,12 @@ bitmap_size (const struct bitmap *b)
 {
   return b->bit_cnt;
 }
-
+
 /* Setting and testing single bits. */
 
 /* Atomically sets the bit numbered IDX in B to VALUE. */
 void
-bitmap_set (struct bitmap *b, size_t idx, bool value) 
+bitmap_set (struct bitmap *b, size_t idx, bool value)
 {
   ASSERT (b != NULL);
   ASSERT (idx < b->bit_cnt);
@@ -154,7 +154,7 @@ bitmap_set (struct bitmap *b, size_t idx, bool value)
 
 /* Atomically sets the bit numbered BIT_IDX in B to true. */
 void
-bitmap_mark (struct bitmap *b, size_t bit_idx) 
+bitmap_mark (struct bitmap *b, size_t bit_idx)
 {
   size_t idx = elem_idx (bit_idx);
   elem_type mask = bit_mask (bit_idx);
@@ -167,7 +167,7 @@ bitmap_mark (struct bitmap *b, size_t bit_idx)
 
 /* Atomically sets the bit numbered BIT_IDX in B to false. */
 void
-bitmap_reset (struct bitmap *b, size_t bit_idx) 
+bitmap_reset (struct bitmap *b, size_t bit_idx)
 {
   size_t idx = elem_idx (bit_idx);
   elem_type mask = bit_mask (bit_idx);
@@ -182,7 +182,7 @@ bitmap_reset (struct bitmap *b, size_t bit_idx)
    that is, if it is true, makes it false,
    and if it is false, makes it true. */
 void
-bitmap_flip (struct bitmap *b, size_t bit_idx) 
+bitmap_flip (struct bitmap *b, size_t bit_idx)
 {
   size_t idx = elem_idx (bit_idx);
   elem_type mask = bit_mask (bit_idx);
@@ -195,18 +195,18 @@ bitmap_flip (struct bitmap *b, size_t bit_idx)
 
 /* Returns the value of the bit numbered IDX in B. */
 bool
-bitmap_test (const struct bitmap *b, size_t idx) 
+bitmap_test (const struct bitmap *b, size_t idx)
 {
   ASSERT (b != NULL);
   ASSERT (idx < b->bit_cnt);
   return (b->bits[elem_idx (idx)] & bit_mask (idx)) != 0;
 }
-
+
 /* Setting and testing multiple bits. */
 
 /* Sets all bits in B to VALUE. */
 void
-bitmap_set_all (struct bitmap *b, bool value) 
+bitmap_set_all (struct bitmap *b, bool value)
 {
   ASSERT (b != NULL);
 
@@ -215,10 +215,10 @@ bitmap_set_all (struct bitmap *b, bool value)
 
 /* Sets the CNT bits starting at START in B to VALUE. */
 void
-bitmap_set_multiple (struct bitmap *b, size_t start, size_t cnt, bool value) 
+bitmap_set_multiple (struct bitmap *b, size_t start, size_t cnt, bool value)
 {
   size_t i;
-  
+
   ASSERT (b != NULL);
   ASSERT (start <= b->bit_cnt);
   ASSERT (start + cnt <= b->bit_cnt);
@@ -230,7 +230,7 @@ bitmap_set_multiple (struct bitmap *b, size_t start, size_t cnt, bool value)
 /* Returns the number of bits in B between START and START + CNT,
    exclusive, that are set to VALUE. */
 size_t
-bitmap_count (const struct bitmap *b, size_t start, size_t cnt, bool value) 
+bitmap_count (const struct bitmap *b, size_t start, size_t cnt, bool value)
 {
   size_t i, value_cnt;
 
@@ -248,10 +248,10 @@ bitmap_count (const struct bitmap *b, size_t start, size_t cnt, bool value)
 /* Returns true if any bits in B between START and START + CNT,
    exclusive, are set to VALUE, and false otherwise. */
 bool
-bitmap_contains (const struct bitmap *b, size_t start, size_t cnt, bool value) 
+bitmap_contains (const struct bitmap *b, size_t start, size_t cnt, bool value)
 {
   size_t i;
-  
+
   ASSERT (b != NULL);
   ASSERT (start <= b->bit_cnt);
   ASSERT (start + cnt <= b->bit_cnt);
@@ -265,7 +265,7 @@ bitmap_contains (const struct bitmap *b, size_t start, size_t cnt, bool value)
 /* Returns true if any bits in B between START and START + CNT,
    exclusive, are set to true, and false otherwise.*/
 bool
-bitmap_any (const struct bitmap *b, size_t start, size_t cnt) 
+bitmap_any (const struct bitmap *b, size_t start, size_t cnt)
 {
   return bitmap_contains (b, start, cnt, true);
 }
@@ -273,7 +273,7 @@ bitmap_any (const struct bitmap *b, size_t start, size_t cnt)
 /* Returns true if no bits in B between START and START + CNT,
    exclusive, are set to true, and false otherwise.*/
 bool
-bitmap_none (const struct bitmap *b, size_t start, size_t cnt) 
+bitmap_none (const struct bitmap *b, size_t start, size_t cnt)
 {
   return !bitmap_contains (b, start, cnt, true);
 }
@@ -281,11 +281,11 @@ bitmap_none (const struct bitmap *b, size_t start, size_t cnt)
 /* Returns true if every bit in B between START and START + CNT,
    exclusive, is set to true, and false otherwise. */
 bool
-bitmap_all (const struct bitmap *b, size_t start, size_t cnt) 
+bitmap_all (const struct bitmap *b, size_t start, size_t cnt)
 {
   return !bitmap_contains (b, start, cnt, false);
 }
-
+
 /* Finding set or unset bits. */
 
 /* Finds and returns the starting index of the first group of CNT
@@ -293,18 +293,18 @@ bitmap_all (const struct bitmap *b, size_t start, size_t cnt)
    VALUE.
    If there is no such group, returns BITMAP_ERROR. */
 size_t
-bitmap_scan (const struct bitmap *b, size_t start, size_t cnt, bool value) 
+bitmap_scan (const struct bitmap *b, size_t start, size_t cnt, bool value)
 {
   ASSERT (b != NULL);
   ASSERT (start <= b->bit_cnt);
 
-  if (cnt <= b->bit_cnt) 
+  if (cnt <= b->bit_cnt)
     {
       size_t last = b->bit_cnt - cnt;
       size_t i;
       for (i = start; i <= last; i++)
         if (!bitmap_contains (b, i, cnt, !value))
-          return i; 
+          return i;
     }
   return BITMAP_ERROR;
 }
@@ -320,17 +320,17 @@ size_t
 bitmap_scan_and_flip (struct bitmap *b, size_t start, size_t cnt, bool value)
 {
   size_t idx = bitmap_scan (b, start, cnt, value);
-  if (idx != BITMAP_ERROR) 
+  if (idx != BITMAP_ERROR)
     bitmap_set_multiple (b, idx, cnt, !value);
   return idx;
 }
-
+
 /* File input and output. */
 
 #ifdef FILESYS
 /* Returns the number of bytes needed to store B in a file. */
 size_t
-bitmap_file_size (const struct bitmap *b) 
+bitmap_file_size (const struct bitmap *b)
 {
   return byte_cnt (b->bit_cnt);
 }
@@ -338,10 +338,10 @@ bitmap_file_size (const struct bitmap *b)
 /* Reads B from FILE.  Returns true if successful, false
    otherwise. */
 bool
-bitmap_read (struct bitmap *b, struct file *file) 
+bitmap_read (struct bitmap *b, struct file *file)
 {
   bool success = true;
-  if (b->bit_cnt > 0) 
+  if (b->bit_cnt > 0)
     {
       off_t size = byte_cnt (b->bit_cnt);
       success = file_read_at (file, b->bits, size, 0) == size;
@@ -359,12 +359,12 @@ bitmap_write (const struct bitmap *b, struct file *file)
   return file_write_at (file, b->bits, size, 0) == size;
 }
 #endif /* FILESYS */
-
+
 /* Debugging. */
 
 /* Dumps the contents of B to the console as hexadecimal. */
 void
-bitmap_dump (const struct bitmap *b) 
+bitmap_dump (const struct bitmap *b)
 {
   hex_dump (0, b->bits, byte_cnt (b->bit_cnt), false);
 }

--- a/pintos/src/lib/kernel/console.c
+++ b/pintos/src/lib/kernel/console.c
@@ -38,7 +38,7 @@ static bool use_console_lock;
    lock_console()
    vprintf()
    printf()               - palloc() tries to grab the lock again
-   palloc_free()        
+   palloc_free()
    thread_schedule_tail() - another thread dying as we switch threads
    schedule()
    thread_yield()
@@ -61,7 +61,7 @@ static int64_t write_cnt;
 
 /* Enable console locking. */
 void
-console_init (void) 
+console_init (void)
 {
   lock_init (&console_lock);
   use_console_lock = true;
@@ -71,48 +71,48 @@ console_init (void)
    which warns it to avoid trying to take the console lock from
    now on. */
 void
-console_panic (void) 
+console_panic (void)
 {
   use_console_lock = false;
 }
 
 /* Prints console statistics. */
 void
-console_print_stats (void) 
+console_print_stats (void)
 {
   printf ("Console: %lld characters output\n", write_cnt);
 }
 
 /* Acquires the console lock. */
 static void
-acquire_console (void) 
+acquire_console (void)
 {
-  if (!intr_context () && use_console_lock) 
+  if (!intr_context () && use_console_lock)
     {
-      if (lock_held_by_current_thread (&console_lock)) 
-        console_lock_depth++; 
+      if (lock_held_by_current_thread (&console_lock))
+        console_lock_depth++;
       else
-        lock_acquire (&console_lock); 
+        lock_acquire (&console_lock);
     }
 }
 
 /* Releases the console lock. */
 static void
-release_console (void) 
+release_console (void)
 {
-  if (!intr_context () && use_console_lock) 
+  if (!intr_context () && use_console_lock)
     {
       if (console_lock_depth > 0)
         console_lock_depth--;
       else
-        lock_release (&console_lock); 
+        lock_release (&console_lock);
     }
 }
 
 /* Returns true if the current thread has the console lock,
    false otherwise. */
 static bool
-console_locked_by_current_thread (void) 
+console_locked_by_current_thread (void)
 {
   return (intr_context ()
           || !use_console_lock
@@ -123,7 +123,7 @@ console_locked_by_current_thread (void)
    which is like printf() but uses a va_list.
    Writes its output to both vga display and serial port. */
 int
-vprintf (const char *format, va_list args) 
+vprintf (const char *format, va_list args)
 {
   int char_cnt = 0;
 
@@ -137,7 +137,7 @@ vprintf (const char *format, va_list args)
 /* Writes string S to the console, followed by a new-line
    character. */
 int
-puts (const char *s) 
+puts (const char *s)
 {
   acquire_console ();
   while (*s != '\0')
@@ -150,7 +150,7 @@ puts (const char *s)
 
 /* Writes the N characters in BUFFER to the console. */
 void
-putbuf (const char *buffer, size_t n) 
+putbuf (const char *buffer, size_t n)
 {
   acquire_console ();
   while (n-- > 0)
@@ -160,18 +160,18 @@ putbuf (const char *buffer, size_t n)
 
 /* Writes C to the vga display and serial port. */
 int
-putchar (int c) 
+putchar (int c)
 {
   acquire_console ();
   putchar_have_lock (c);
   release_console ();
-  
+
   return c;
 }
-
+
 /* Helper function for vprintf(). */
 static void
-vprintf_helper (char c, void *char_cnt_) 
+vprintf_helper (char c, void *char_cnt_)
 {
   int *char_cnt = char_cnt_;
   (*char_cnt)++;
@@ -182,7 +182,7 @@ vprintf_helper (char c, void *char_cnt_)
    The caller has already acquired the console lock if
    appropriate. */
 static void
-putchar_have_lock (uint8_t c) 
+putchar_have_lock (uint8_t c)
 {
   ASSERT (console_locked_by_current_thread ());
   write_cnt++;

--- a/pintos/src/lib/kernel/debug.c
+++ b/pintos/src/lib/kernel/debug.c
@@ -26,7 +26,7 @@ debug_panic (const char *file, int line, const char *function,
   console_panic ();
 
   level++;
-  if (level == 1) 
+  if (level == 1)
     {
       printf ("Kernel PANIC at %s:%d in %s(): ", file, line, function);
 
@@ -40,7 +40,7 @@ debug_panic (const char *file, int line, const char *function,
   else if (level == 2)
     printf ("Kernel PANIC recursion at %s:%d in %s().\n",
             file, line, function);
-  else 
+  else
     {
       /* Don't print anything: that's probably why we recursed. */
     }
@@ -59,15 +59,15 @@ print_stacktrace(struct thread *t, void *aux UNUSED)
   const char *status = "UNKNOWN";
 
   switch (t->status) {
-    case THREAD_RUNNING:  
+    case THREAD_RUNNING:
       status = "RUNNING";
       break;
 
-    case THREAD_READY:  
+    case THREAD_READY:
       status = "READY";
       break;
 
-    case THREAD_BLOCKED:  
+    case THREAD_BLOCKED:
       status = "BLOCKED";
       break;
 
@@ -77,7 +77,7 @@ print_stacktrace(struct thread *t, void *aux UNUSED)
 
   printf ("Call stack of thread `%s' (status %s):", t->name, status);
 
-  if (t == thread_current()) 
+  if (t == thread_current())
     {
       frame = __builtin_frame_address (1);
       retaddr = __builtin_return_address (0);
@@ -92,8 +92,8 @@ print_stacktrace(struct thread *t, void *aux UNUSED)
 
       /* Skip threads if they have been added to the all threads
          list, but have never been scheduled.
-         We can identify because their `stack' member either points 
-         at the top of their kernel stack page, or the 
+         We can identify because their `stack' member either points
+         at the top of their kernel stack page, or the
          switch_threads_frame's 'eip' member points at switch_entry.
          See also threads.c. */
       if (t->stack == (uint8_t *)t + PGSIZE || saved_frame->eip == switch_entry)

--- a/pintos/src/lib/kernel/hash.c
+++ b/pintos/src/lib/kernel/hash.c
@@ -23,7 +23,7 @@ static void rehash (struct hash *);
    compare hash elements using LESS, given auxiliary data AUX. */
 bool
 hash_init (struct hash *h,
-           hash_hash_func *hash, hash_less_func *less, void *aux) 
+           hash_hash_func *hash, hash_less_func *less, void *aux)
 {
   h->elem_cnt = 0;
   h->bucket_cnt = 4;
@@ -32,7 +32,7 @@ hash_init (struct hash *h,
   h->less = less;
   h->aux = aux;
 
-  if (h->buckets != NULL) 
+  if (h->buckets != NULL)
     {
       hash_clear (h, NULL);
       return true;
@@ -42,7 +42,7 @@ hash_init (struct hash *h,
 }
 
 /* Removes all the elements from H.
-   
+
    If DESTRUCTOR is non-null, then it is called for each element
    in the hash.  DESTRUCTOR may, if appropriate, deallocate the
    memory used by the hash element.  However, modifying hash
@@ -51,24 +51,24 @@ hash_init (struct hash *h,
    hash_replace(), or hash_delete(), yields undefined behavior,
    whether done in DESTRUCTOR or elsewhere. */
 void
-hash_clear (struct hash *h, hash_action_func *destructor) 
+hash_clear (struct hash *h, hash_action_func *destructor)
 {
   size_t i;
 
-  for (i = 0; i < h->bucket_cnt; i++) 
+  for (i = 0; i < h->bucket_cnt; i++)
     {
       struct list *bucket = &h->buckets[i];
 
-      if (destructor != NULL) 
-        while (!list_empty (bucket)) 
+      if (destructor != NULL)
+        while (!list_empty (bucket))
           {
             struct list_elem *list_elem = list_pop_front (bucket);
             struct hash_elem *hash_elem = list_elem_to_hash_elem (list_elem);
             destructor (hash_elem, h->aux);
           }
 
-      list_init (bucket); 
-    }    
+      list_init (bucket);
+    }
 
   h->elem_cnt = 0;
 }
@@ -84,7 +84,7 @@ hash_clear (struct hash *h, hash_action_func *destructor)
    undefined behavior, whether done in DESTRUCTOR or
    elsewhere. */
 void
-hash_destroy (struct hash *h, hash_action_func *destructor) 
+hash_destroy (struct hash *h, hash_action_func *destructor)
 {
   if (destructor != NULL)
     hash_clear (h, destructor);
@@ -94,25 +94,25 @@ hash_destroy (struct hash *h, hash_action_func *destructor)
 /* Inserts NEW into hash table H and returns a null pointer, if
    no equal element is already in the table.
    If an equal element is already in the table, returns it
-   without inserting NEW. */   
+   without inserting NEW. */
 struct hash_elem *
 hash_insert (struct hash *h, struct hash_elem *new)
 {
   struct list *bucket = find_bucket (h, new);
   struct hash_elem *old = find_elem (h, bucket, new);
 
-  if (old == NULL) 
+  if (old == NULL)
     insert_elem (h, bucket, new);
 
   rehash (h);
 
-  return old; 
+  return old;
 }
 
 /* Inserts NEW into hash table H, replacing any equal element
    already in the table, which is returned. */
 struct hash_elem *
-hash_replace (struct hash *h, struct hash_elem *new) 
+hash_replace (struct hash *h, struct hash_elem *new)
 {
   struct list *bucket = find_bucket (h, new);
   struct hash_elem *old = find_elem (h, bucket, new);
@@ -129,7 +129,7 @@ hash_replace (struct hash *h, struct hash_elem *new)
 /* Finds and returns an element equal to E in hash table H, or a
    null pointer if no equal element exists in the table. */
 struct hash_elem *
-hash_find (struct hash *h, struct hash_elem *e) 
+hash_find (struct hash *h, struct hash_elem *e)
 {
   return find_elem (h, find_bucket (h, e), e);
 }
@@ -145,33 +145,33 @@ struct hash_elem *
 hash_delete (struct hash *h, struct hash_elem *e)
 {
   struct hash_elem *found = find_elem (h, find_bucket (h, e), e);
-  if (found != NULL) 
+  if (found != NULL)
     {
       remove_elem (h, found);
-      rehash (h); 
+      rehash (h);
     }
   return found;
 }
 
 /* Calls ACTION for each element in hash table H in arbitrary
-   order. 
+   order.
    Modifying hash table H while hash_apply() is running, using
    any of the functions hash_clear(), hash_destroy(),
    hash_insert(), hash_replace(), or hash_delete(), yields
    undefined behavior, whether done from ACTION or elsewhere. */
 void
-hash_apply (struct hash *h, hash_action_func *action) 
+hash_apply (struct hash *h, hash_action_func *action)
 {
   size_t i;
-  
+
   ASSERT (action != NULL);
 
-  for (i = 0; i < h->bucket_cnt; i++) 
+  for (i = 0; i < h->bucket_cnt; i++)
     {
       struct list *bucket = &h->buckets[i];
       struct list_elem *elem, *next;
 
-      for (elem = list_begin (bucket); elem != list_end (bucket); elem = next) 
+      for (elem = list_begin (bucket); elem != list_end (bucket); elem = next)
         {
           next = list_next (elem);
           action (list_elem_to_hash_elem (elem), h->aux);
@@ -197,7 +197,7 @@ hash_apply (struct hash *h, hash_action_func *action)
    hash_replace(), or hash_delete(), invalidates all
    iterators. */
 void
-hash_first (struct hash_iterator *i, struct hash *h) 
+hash_first (struct hash_iterator *i, struct hash *h)
 {
   ASSERT (i != NULL);
   ASSERT (h != NULL);
@@ -230,7 +230,7 @@ hash_next (struct hash_iterator *i)
         }
       i->elem = list_elem_to_hash_elem (list_begin (i->bucket));
     }
-  
+
   return i->elem;
 }
 
@@ -238,21 +238,21 @@ hash_next (struct hash_iterator *i)
    null pointer at the end of the table.  Undefined behavior
    after calling hash_first() but before hash_next(). */
 struct hash_elem *
-hash_cur (struct hash_iterator *i) 
+hash_cur (struct hash_iterator *i)
 {
   return i->elem;
 }
 
 /* Returns the number of elements in H. */
 size_t
-hash_size (struct hash *h) 
+hash_size (struct hash *h)
 {
   return h->elem_cnt;
 }
 
 /* Returns true if H contains no elements, false otherwise. */
 bool
-hash_empty (struct hash *h) 
+hash_empty (struct hash *h)
 {
   return h->elem_cnt == 0;
 }
@@ -276,11 +276,11 @@ hash_bytes (const void *buf_, size_t size)
     hash = (hash * FNV_32_PRIME) ^ *buf++;
 
   return hash;
-} 
+}
 
 /* Returns a hash of string S. */
 unsigned
-hash_string (const char *s_) 
+hash_string (const char *s_)
 {
   const unsigned char *s = (const unsigned char *) s_;
   unsigned hash;
@@ -296,14 +296,14 @@ hash_string (const char *s_)
 
 /* Returns a hash of integer I. */
 unsigned
-hash_int (int i) 
+hash_int (int i)
 {
   return hash_bytes (&i, sizeof i);
 }
-
+
 /* Returns the bucket in H that E belongs in. */
 static struct list *
-find_bucket (struct hash *h, struct hash_elem *e) 
+find_bucket (struct hash *h, struct hash_elem *e)
 {
   size_t bucket_idx = h->hash (e, h->aux) & (h->bucket_cnt - 1);
   return &h->buckets[bucket_idx];
@@ -312,29 +312,29 @@ find_bucket (struct hash *h, struct hash_elem *e)
 /* Searches BUCKET in H for a hash element equal to E.  Returns
    it if found or a null pointer otherwise. */
 static struct hash_elem *
-find_elem (struct hash *h, struct list *bucket, struct hash_elem *e) 
+find_elem (struct hash *h, struct list *bucket, struct hash_elem *e)
 {
   struct list_elem *i;
 
-  for (i = list_begin (bucket); i != list_end (bucket); i = list_next (i)) 
+  for (i = list_begin (bucket); i != list_end (bucket); i = list_next (i))
     {
       struct hash_elem *hi = list_elem_to_hash_elem (i);
       if (!h->less (hi, e, h->aux) && !h->less (e, hi, h->aux))
-        return hi; 
+        return hi;
     }
   return NULL;
 }
 
 /* Returns X with its lowest-order bit set to 1 turned off. */
 static inline size_t
-turn_off_least_1bit (size_t x) 
+turn_off_least_1bit (size_t x)
 {
   return x & (x - 1);
 }
 
 /* Returns true if X is a power of 2, otherwise false. */
 static inline size_t
-is_power_of_2 (size_t x) 
+is_power_of_2 (size_t x)
 {
   return x != 0 && turn_off_least_1bit (x) == 0;
 }
@@ -349,7 +349,7 @@ is_power_of_2 (size_t x)
    condition, but that'll just make hash accesses less efficient;
    we can still continue. */
 static void
-rehash (struct hash *h) 
+rehash (struct hash *h)
 {
   size_t old_bucket_cnt, new_bucket_cnt;
   struct list *new_buckets, *old_buckets;
@@ -377,14 +377,14 @@ rehash (struct hash *h)
 
   /* Allocate new buckets and initialize them as empty. */
   new_buckets = malloc (sizeof *new_buckets * new_bucket_cnt);
-  if (new_buckets == NULL) 
+  if (new_buckets == NULL)
     {
       /* Allocation failed.  This means that use of the hash table will
          be less efficient.  However, it is still usable, so
          there's no reason for it to be an error. */
       return;
     }
-  for (i = 0; i < new_bucket_cnt; i++) 
+  for (i = 0; i < new_bucket_cnt; i++)
     list_init (&new_buckets[i]);
 
   /* Install new bucket info. */
@@ -392,14 +392,14 @@ rehash (struct hash *h)
   h->bucket_cnt = new_bucket_cnt;
 
   /* Move each old element into the appropriate new bucket. */
-  for (i = 0; i < old_bucket_cnt; i++) 
+  for (i = 0; i < old_bucket_cnt; i++)
     {
       struct list *old_bucket;
       struct list_elem *elem, *next;
 
       old_bucket = &old_buckets[i];
       for (elem = list_begin (old_bucket);
-           elem != list_end (old_bucket); elem = next) 
+           elem != list_end (old_bucket); elem = next)
         {
           struct list *new_bucket
             = find_bucket (h, list_elem_to_hash_elem (elem));
@@ -414,7 +414,7 @@ rehash (struct hash *h)
 
 /* Inserts E into BUCKET (in hash table H). */
 static void
-insert_elem (struct hash *h, struct list *bucket, struct hash_elem *e) 
+insert_elem (struct hash *h, struct list *bucket, struct hash_elem *e)
 {
   h->elem_cnt++;
   list_push_front (bucket, &e->list_elem);
@@ -422,7 +422,7 @@ insert_elem (struct hash *h, struct list *bucket, struct hash_elem *e)
 
 /* Removes E from hash table H. */
 static void
-remove_elem (struct hash *h, struct hash_elem *e) 
+remove_elem (struct hash *h, struct hash_elem *e)
 {
   h->elem_cnt--;
   list_remove (&e->list_elem);

--- a/pintos/src/lib/kernel/hash.h
+++ b/pintos/src/lib/kernel/hash.h
@@ -26,7 +26,7 @@
 #include "list.h"
 
 /* Hash element. */
-struct hash_elem 
+struct hash_elem
   {
     struct list_elem list_elem;
   };
@@ -56,7 +56,7 @@ typedef bool hash_less_func (const struct hash_elem *a,
 typedef void hash_action_func (struct hash_elem *e, void *aux);
 
 /* Hash table. */
-struct hash 
+struct hash
   {
     size_t elem_cnt;            /* Number of elements in table. */
     size_t bucket_cnt;          /* Number of buckets, a power of 2. */
@@ -67,7 +67,7 @@ struct hash
   };
 
 /* A hash table iterator. */
-struct hash_iterator 
+struct hash_iterator
   {
     struct hash *hash;          /* The hash table. */
     struct list *bucket;        /* Current bucket. */

--- a/pintos/src/lib/kernel/list.c
+++ b/pintos/src/lib/kernel/list.c
@@ -100,7 +100,7 @@ list_end (struct list *list)
 /* Returns the LIST's reverse beginning, for iterating through
    LIST in reverse order, from back to front. */
 struct list_elem *
-list_rbegin (struct list *list) 
+list_rbegin (struct list *list)
 {
   ASSERT (list != NULL);
   return list->tail.prev;
@@ -130,7 +130,7 @@ list_prev (struct list_elem *elem)
         }
 */
 struct list_elem *
-list_rend (struct list *list) 
+list_rend (struct list *list)
 {
   ASSERT (list != NULL);
   return &list->head;
@@ -142,13 +142,13 @@ list_rend (struct list *list)
    through a list, e.g.:
 
       e = list_head (&list);
-      while ((e = list_next (e)) != list_end (&list)) 
+      while ((e = list_next (e)) != list_end (&list))
         {
           ...
         }
 */
 struct list_elem *
-list_head (struct list *list) 
+list_head (struct list *list)
 {
   ASSERT (list != NULL);
   return &list->head;
@@ -156,7 +156,7 @@ list_head (struct list *list)
 
 /* Return's LIST's tail. */
 struct list_elem *
-list_tail (struct list *list) 
+list_tail (struct list *list)
 {
   ASSERT (list != NULL);
   return &list->tail;
@@ -314,7 +314,7 @@ list_empty (struct list *list)
 
 /* Swaps the `struct list_elem *'s that A and B point to. */
 static void
-swap (struct list_elem **a, struct list_elem **b) 
+swap (struct list_elem **a, struct list_elem **b)
 {
   struct list_elem *t = *a;
   *a = *b;
@@ -325,7 +325,7 @@ swap (struct list_elem **a, struct list_elem **b)
 void
 list_reverse (struct list *list)
 {
-  if (!list_empty (list)) 
+  if (!list_empty (list))
     {
       struct list_elem *e;
 
@@ -343,7 +343,7 @@ is_sorted (struct list_elem *a, struct list_elem *b,
            list_less_func *less, void *aux)
 {
   if (a != b)
-    while ((a = list_next (a)) != b) 
+    while ((a = list_next (a)) != b)
       if (less (a, list_prev (a), aux))
         return false;
   return true;
@@ -362,8 +362,8 @@ find_end_of_run (struct list_elem *a, struct list_elem *b,
   ASSERT (b != NULL);
   ASSERT (less != NULL);
   ASSERT (a != b);
-  
-  do 
+
+  do
     {
       a = list_next (a);
     }
@@ -389,9 +389,9 @@ inplace_merge (struct list_elem *a0, struct list_elem *a1b0,
   ASSERT (is_sorted (a1b0, b1, less, aux));
 
   while (a0 != a1b0 && a1b0 != b1)
-    if (!less (a1b0, a0, aux)) 
+    if (!less (a1b0, a0, aux))
       a0 = list_next (a0);
-    else 
+    else
       {
         a1b0 = list_next (a1b0);
         list_splice (a0, list_prev (a1b0), a1b0);
@@ -475,7 +475,7 @@ list_unique (struct list *list, struct list *duplicates,
 
   elem = list_begin (list);
   while ((next = list_next (elem)) != list_end (list))
-    if (!less (elem, next, aux) && !less (next, elem, aux)) 
+    if (!less (elem, next, aux) && !less (next, elem, aux))
       {
         list_remove (next);
         if (duplicates != NULL)
@@ -493,13 +493,13 @@ struct list_elem *
 list_max (struct list *list, list_less_func *less, void *aux)
 {
   struct list_elem *max = list_begin (list);
-  if (max != list_end (list)) 
+  if (max != list_end (list))
     {
       struct list_elem *e;
-      
+
       for (e = list_next (max); e != list_end (list); e = list_next (e))
         if (less (max, e, aux))
-          max = e; 
+          max = e;
     }
   return max;
 }
@@ -512,13 +512,13 @@ struct list_elem *
 list_min (struct list *list, list_less_func *less, void *aux)
 {
   struct list_elem *min = list_begin (list);
-  if (min != list_end (list)) 
+  if (min != list_end (list))
     {
       struct list_elem *e;
-      
+
       for (e = list_next (min); e != list_end (list); e = list_next (e))
         if (less (e, min, aux))
-          min = e; 
+          min = e;
     }
   return min;
 }

--- a/pintos/src/lib/kernel/list.h
+++ b/pintos/src/lib/kernel/list.h
@@ -87,14 +87,14 @@
 #include <stdint.h>
 
 /* List element. */
-struct list_elem 
+struct list_elem
   {
     struct list_elem *prev;     /* Previous list element. */
     struct list_elem *next;     /* Next list element. */
   };
 
 /* List. */
-struct list 
+struct list
   {
     struct list_elem head;      /* List head. */
     struct list_elem tail;      /* List tail. */
@@ -158,7 +158,7 @@ bool list_empty (struct list *);
 
 /* Miscellaneous. */
 void list_reverse (struct list *);
-
+
 /* Compares the value of two list elements A and B, given
    auxiliary data AUX.  Returns true if A is less than B, or
    false if A is greater than or equal to B. */

--- a/pintos/src/lib/random.c
+++ b/pintos/src/lib/random.c
@@ -18,11 +18,11 @@ static uint8_t s[256];          /* S[]. */
 static uint8_t s_i, s_j;        /* i, j. */
 
 /* Already initialized? */
-static bool inited;     
+static bool inited;
 
 /* Swaps the bytes pointed to by A and B. */
 static inline void
-swap_byte (uint8_t *a, uint8_t *b) 
+swap_byte (uint8_t *a, uint8_t *b)
 {
   uint8_t t = *a;
   *a = *b;
@@ -37,9 +37,9 @@ random_init (unsigned seed)
   int i;
   uint8_t j;
 
-  for (i = 0; i < 256; i++) 
+  for (i = 0; i < 256; i++)
     s[i] = i;
-  for (i = j = 0; i < 256; i++) 
+  for (i = j = 0; i < 256; i++)
     {
       j += s[i] + seedp[i % sizeof seed];
       swap_byte (s + i, s + j);
@@ -51,7 +51,7 @@ random_init (unsigned seed)
 
 /* Writes SIZE random bytes into BUF. */
 void
-random_bytes (void *buf_, size_t size) 
+random_bytes (void *buf_, size_t size)
 {
   uint8_t *buf;
 
@@ -61,7 +61,7 @@ random_bytes (void *buf_, size_t size)
   for (buf = buf_; size-- > 0; buf++)
     {
       uint8_t s_k;
-      
+
       s_i++;
       s_j += s[s_i];
       swap_byte (s + s_i, s + s_j);
@@ -75,7 +75,7 @@ random_bytes (void *buf_, size_t size)
    Use random_ulong() % n to obtain a random number in the range
    0...n (exclusive). */
 unsigned long
-random_ulong (void) 
+random_ulong (void)
 {
   unsigned long ul;
   random_bytes (&ul, sizeof ul);

--- a/pintos/src/lib/stdio.c
+++ b/pintos/src/lib/stdio.c
@@ -6,7 +6,7 @@
 #include <string.h>
 
 /* Auxiliary data for vsnprintf_helper(). */
-struct vsnprintf_aux 
+struct vsnprintf_aux
   {
     char *p;            /* Current output position. */
     int length;         /* Length of output string. */
@@ -23,7 +23,7 @@ static void vsnprintf_helper (char, void *);
    have been written to BUFFER, not including a null terminator,
    had there been enough room. */
 int
-vsnprintf (char *buffer, size_t buf_size, const char *format, va_list args) 
+vsnprintf (char *buffer, size_t buf_size, const char *format, va_list args)
 {
   /* Set up aux data for vsnprintf_helper(). */
   struct vsnprintf_aux aux;
@@ -59,7 +59,7 @@ vsnprintf_helper (char ch, void *aux_)
    have been written to BUFFER, not including a null terminator,
    had there been enough room. */
 int
-snprintf (char *buffer, size_t buf_size, const char *format, ...) 
+snprintf (char *buffer, size_t buf_size, const char *format, ...)
 {
   va_list args;
   int retval;
@@ -76,7 +76,7 @@ snprintf (char *buffer, size_t buf_size, const char *format, ...)
    serial port.
    In userspace, the console is file descriptor 1. */
 int
-printf (const char *format, ...) 
+printf (const char *format, ...)
 {
   va_list args;
   int retval;
@@ -87,14 +87,14 @@ printf (const char *format, ...)
 
   return retval;
 }
-
+
 /* printf() formatting internals. */
 
 /* A printf() conversion. */
-struct printf_conversion 
+struct printf_conversion
   {
     /* Flags. */
-    enum 
+    enum
       {
         MINUS = 1 << 0,         /* '-' */
         PLUS = 1 << 1,          /* '+' */
@@ -113,7 +113,7 @@ struct printf_conversion
     int precision;
 
     /* Type of argument to format. */
-    enum 
+    enum
       {
         CHAR = 1,               /* hh */
         SHORT = 2,              /* h */
@@ -127,7 +127,7 @@ struct printf_conversion
     type;
   };
 
-struct integer_base 
+struct integer_base
   {
     int base;                   /* Base. */
     const char *digits;         /* Collection of digits. */
@@ -143,7 +143,7 @@ static const struct integer_base base_X = {16, "0123456789ABCDEF", 'X', 4};
 static const char *parse_conversion (const char *format,
                                      struct printf_conversion *,
                                      va_list *);
-static void format_integer (uintmax_t value, bool is_signed, bool negative, 
+static void format_integer (uintmax_t value, bool is_signed, bool negative,
                             const struct integer_base *,
                             const struct printf_conversion *,
                             void (*output) (char, void *), void *aux);
@@ -162,7 +162,7 @@ __vprintf (const char *format, va_list args,
       struct printf_conversion c;
 
       /* Literally copy non-conversions to output. */
-      if (*format != '%') 
+      if (*format != '%')
         {
           output (*format, aux);
           continue;
@@ -170,7 +170,7 @@ __vprintf (const char *format, va_list args,
       format++;
 
       /* %% => %. */
-      if (*format == '%') 
+      if (*format == '%')
         {
           output ('%', aux);
           continue;
@@ -180,17 +180,17 @@ __vprintf (const char *format, va_list args,
       format = parse_conversion (format, &c, &args);
 
       /* Do conversion. */
-      switch (*format) 
+      switch (*format)
         {
         case 'd':
-        case 'i': 
+        case 'i':
           {
             /* Signed integer conversions. */
             intmax_t value;
-            
-            switch (c.type) 
+
+            switch (c.type)
               {
-              case CHAR: 
+              case CHAR:
                 value = (signed char) va_arg (args, int);
                 break;
               case SHORT:
@@ -224,7 +224,7 @@ __vprintf (const char *format, va_list args,
                             true, value < 0, &base_d, &c, output, aux);
           }
           break;
-          
+
         case 'o':
         case 'u':
         case 'x':
@@ -234,9 +234,9 @@ __vprintf (const char *format, va_list args,
             uintmax_t value;
             const struct integer_base *b;
 
-            switch (c.type) 
+            switch (c.type)
               {
-              case CHAR: 
+              case CHAR:
                 value = (unsigned char) va_arg (args, unsigned);
                 break;
               case SHORT:
@@ -267,7 +267,7 @@ __vprintf (const char *format, va_list args,
                 NOT_REACHED ();
               }
 
-            switch (*format) 
+            switch (*format)
               {
               case 'o': b = &base_o; break;
               case 'u': b = &base_d; break;
@@ -280,7 +280,7 @@ __vprintf (const char *format, va_list args,
           }
           break;
 
-        case 'c': 
+        case 'c':
           {
             /* Treat character as single-character string. */
             char ch = va_arg (args, int);
@@ -301,7 +301,7 @@ __vprintf (const char *format, va_list args,
             format_string (s, strnlen (s, c.precision), &c, output, aux);
           }
           break;
-          
+
         case 'p':
           {
             /* Pointer conversion.
@@ -313,7 +313,7 @@ __vprintf (const char *format, va_list args,
                             &base_x, &c, output, aux);
           }
           break;
-      
+
         case 'f':
         case 'e':
         case 'E':
@@ -338,13 +338,13 @@ __vprintf (const char *format, va_list args,
    *ARGS for `*' field widths and precisions. */
 static const char *
 parse_conversion (const char *format, struct printf_conversion *c,
-                  va_list *args) 
+                  va_list *args)
 {
   /* Parse flag characters. */
   c->flags = 0;
-  for (;;) 
+  for (;;)
     {
-      switch (*format++) 
+      switch (*format++)
         {
         case '-':
           c->flags |= MINUS;
@@ -382,34 +382,34 @@ parse_conversion (const char *format, struct printf_conversion *c,
       format++;
       c->width = va_arg (*args, int);
     }
-  else 
+  else
     {
       for (; isdigit (*format); format++)
         c->width = c->width * 10 + *format - '0';
     }
-  if (c->width < 0) 
+  if (c->width < 0)
     {
       c->width = -c->width;
       c->flags |= MINUS;
     }
-      
+
   /* Parse precision. */
   c->precision = -1;
-  if (*format == '.') 
+  if (*format == '.')
     {
       format++;
-      if (*format == '*') 
+      if (*format == '*')
         {
           format++;
           c->precision = va_arg (*args, int);
         }
-      else 
+      else
         {
           c->precision = 0;
           for (; isdigit (*format); format++)
             c->precision = c->precision * 10 + *format - '0';
         }
-      if (c->precision < 0) 
+      if (c->precision < 0)
         c->precision = -1;
     }
   if (c->precision >= 0)
@@ -417,10 +417,10 @@ parse_conversion (const char *format, struct printf_conversion *c,
 
   /* Parse type. */
   c->type = INT;
-  switch (*format++) 
+  switch (*format++)
     {
     case 'h':
-      if (*format == 'h') 
+      if (*format == 'h')
         {
           format++;
           c->type = CHAR;
@@ -428,7 +428,7 @@ parse_conversion (const char *format, struct printf_conversion *c,
       else
         c->type = SHORT;
       break;
-      
+
     case 'j':
       c->type = INTMAX;
       break;
@@ -467,7 +467,7 @@ parse_conversion (const char *format, struct printf_conversion *c,
    according to the provided base B.  Details of the conversion
    are in C. */
 static void
-format_integer (uintmax_t value, bool is_signed, bool negative, 
+format_integer (uintmax_t value, bool is_signed, bool negative,
                 const struct integer_base *b,
                 const struct printf_conversion *c,
                 void (*output) (char, void *), void *aux)
@@ -483,7 +483,7 @@ format_integer (uintmax_t value, bool is_signed, bool negative,
      An unsigned conversion will never have a sign character,
      even if one of the flags requests one. */
   sign = 0;
-  if (is_signed) 
+  if (is_signed)
     {
       if (c->flags & PLUS)
         sign = negative ? '-' : '+';
@@ -503,7 +503,7 @@ format_integer (uintmax_t value, bool is_signed, bool negative,
      will output the buffer's content in reverse. */
   cp = buf;
   digit_cnt = 0;
-  while (value > 0) 
+  while (value > 0)
     {
       if ((c->flags & GROUP) && digit_cnt > 0 && digit_cnt % b->group == 0)
         *cp++ = ',';
@@ -533,10 +533,10 @@ format_integer (uintmax_t value, bool is_signed, bool negative,
     output_dup (' ', pad_cnt, output, aux);
   if (sign)
     output (sign, aux);
-  if (x) 
+  if (x)
     {
       output ('0', aux);
-      output (x, aux); 
+      output (x, aux);
     }
   if (c->flags & ZERO)
     output_dup ('0', pad_cnt, output, aux);
@@ -548,7 +548,7 @@ format_integer (uintmax_t value, bool is_signed, bool negative,
 
 /* Writes CH to OUTPUT with auxiliary data AUX, CNT times. */
 static void
-output_dup (char ch, size_t cnt, void (*output) (char, void *), void *aux) 
+output_dup (char ch, size_t cnt, void (*output) (char, void *), void *aux)
 {
   while (cnt-- > 0)
     output (ch, aux);
@@ -560,7 +560,7 @@ output_dup (char ch, size_t cnt, void (*output) (char, void *), void *aux)
 static void
 format_string (const char *string, int length,
                struct printf_conversion *c,
-               void (*output) (char, void *), void *aux) 
+               void (*output) (char, void *), void *aux)
 {
   int i;
   if (c->width > length && (c->flags & MINUS) == 0)
@@ -575,7 +575,7 @@ format_string (const char *string, int length,
    va_list. */
 void
 __printf (const char *format,
-          void (*output) (char, void *), void *aux, ...) 
+          void (*output) (char, void *), void *aux, ...)
 {
   va_list args;
 
@@ -583,12 +583,12 @@ __printf (const char *format,
   __vprintf (format, args, output, aux);
   va_end (args);
 }
-
+
 /* Dumps the SIZE bytes in BUF to the console as hex bytes
    arranged 16 per line.  Numeric offsets are also included,
    starting at OFS for the first byte in BUF.  If ASCII is true
    then the corresponding ASCII characters are also rendered
-   alongside. */   
+   alongside. */
 void
 hex_dump (uintptr_t ofs, const void *buf_, size_t size, bool ascii)
 {
@@ -599,7 +599,7 @@ hex_dump (uintptr_t ofs, const void *buf_, size_t size, bool ascii)
     {
       size_t start, end, n;
       size_t i;
-      
+
       /* Number of bytes on this line. */
       start = ofs % per_line;
       end = per_line;
@@ -611,10 +611,10 @@ hex_dump (uintptr_t ofs, const void *buf_, size_t size, bool ascii)
       printf ("%08jx  ", (uintmax_t) ROUND_DOWN (ofs, per_line));
       for (i = 0; i < start; i++)
         printf ("   ");
-      for (; i < end; i++) 
+      for (; i < end; i++)
         printf ("%02hhx%c",
                 buf[i - start], i == per_line / 2 - 1? '-' : ' ');
-      if (ascii) 
+      if (ascii)
         {
           for (; i < per_line; i++)
             printf ("   ");
@@ -639,11 +639,11 @@ hex_dump (uintptr_t ofs, const void *buf_, size_t size, bool ascii)
 /* Prints SIZE, which represents a number of bytes, in a
    human-readable format, e.g. "256 kB". */
 void
-print_human_readable_size (uint64_t size) 
+print_human_readable_size (uint64_t size)
 {
   if (size == 1)
     printf ("1 byte");
-  else 
+  else
     {
       static const char *factors[] = {"bytes", "kB", "MB", "GB", "TB", NULL};
       const char **fp;

--- a/pintos/src/lib/stdlib.c
+++ b/pintos/src/lib/stdlib.c
@@ -7,7 +7,7 @@
 /* Converts a string representation of a signed decimal integer
    in S into an `int', which is returned. */
 int
-atoi (const char *s) 
+atoi (const char *s)
 {
   bool negative;
   int value;
@@ -42,7 +42,7 @@ atoi (const char *s)
 
 /* Compares A and B by calling the AUX function. */
 static int
-compare_thunk (const void *a, const void *b, void *aux) 
+compare_thunk (const void *a, const void *b, void *aux)
 {
   int (**compare) (const void *, const void *) = aux;
   return (*compare) (a, b);
@@ -56,7 +56,7 @@ compare_thunk (const void *a, const void *b, void *aux)
    CNT. */
 void
 qsort (void *array, size_t cnt, size_t size,
-       int (*compare) (const void *, const void *)) 
+       int (*compare) (const void *, const void *))
 {
   sort (array, cnt, size, compare_thunk, &compare);
 }
@@ -85,7 +85,7 @@ do_swap (unsigned char *array, size_t a_idx, size_t b_idx, size_t size)
 static int
 do_compare (unsigned char *array, size_t a_idx, size_t b_idx, size_t size,
             int (*compare) (const void *, const void *, void *aux),
-            void *aux) 
+            void *aux)
 {
   return compare (array + (a_idx - 1) * size, array + (b_idx - 1) * size, aux);
 }
@@ -96,9 +96,9 @@ do_compare (unsigned char *array, size_t a_idx, size_t b_idx, size_t size,
 static void
 heapify (unsigned char *array, size_t i, size_t cnt, size_t size,
          int (*compare) (const void *, const void *, void *aux),
-         void *aux) 
+         void *aux)
 {
-  for (;;) 
+  for (;;)
     {
       /* Set `max' to the index of the largest element among I
          and its children (if any). */
@@ -108,7 +108,7 @@ heapify (unsigned char *array, size_t i, size_t cnt, size_t size,
       if (left <= cnt && do_compare (array, left, max, size, compare, aux) > 0)
         max = left;
       if (right <= cnt
-          && do_compare (array, right, max, size, compare, aux) > 0) 
+          && do_compare (array, right, max, size, compare, aux) > 0)
         max = right;
 
       /* If the maximum value is already in element I, we're
@@ -131,7 +131,7 @@ heapify (unsigned char *array, size_t i, size_t cnt, size_t size,
 void
 sort (void *array, size_t cnt, size_t size,
       int (*compare) (const void *, const void *, void *aux),
-      void *aux) 
+      void *aux)
 {
   size_t i;
 
@@ -144,10 +144,10 @@ sort (void *array, size_t cnt, size_t size,
     heapify (array, i, cnt, size, compare, aux);
 
   /* Sort the heap. */
-  for (i = cnt; i > 1; i--) 
+  for (i = cnt; i > 1; i--)
     {
       do_swap (array, 1, i, size);
-      heapify (array, 1, i - 1, size, compare, aux); 
+      heapify (array, 1, i - 1, size, compare, aux);
     }
 }
 
@@ -164,7 +164,7 @@ sort (void *array, size_t cnt, size_t size,
    == B, greater than zero if A > B. */
 void *
 bsearch (const void *key, const void *array, size_t cnt,
-         size_t size, int (*compare) (const void *, const void *)) 
+         size_t size, int (*compare) (const void *, const void *))
 {
   return binary_search (key, array, cnt, size, compare_thunk, &compare);
 }
@@ -184,25 +184,25 @@ bsearch (const void *key, const void *array, size_t cnt,
 void *
 binary_search (const void *key, const void *array, size_t cnt, size_t size,
                int (*compare) (const void *, const void *, void *aux),
-               void *aux) 
+               void *aux)
 {
   const unsigned char *first = array;
   const unsigned char *last = array + size * cnt;
 
-  while (first < last) 
+  while (first < last)
     {
       size_t range = (last - first) / size;
       const unsigned char *middle = first + (range / 2) * size;
       int cmp = compare (key, middle, aux);
 
-      if (cmp < 0) 
+      if (cmp < 0)
         last = middle;
-      else if (cmp > 0) 
+      else if (cmp > 0)
         first = middle + size;
       else
         return (void *) middle;
     }
-  
+
   return NULL;
 }
 

--- a/pintos/src/lib/string.c
+++ b/pintos/src/lib/string.c
@@ -4,7 +4,7 @@
 /* Copies SIZE bytes from SRC to DST, which must not overlap.
    Returns DST. */
 void *
-memcpy (void *dst_, const void *src_, size_t size) 
+memcpy (void *dst_, const void *src_, size_t size)
 {
   unsigned char *dst = dst_;
   const unsigned char *src = src_;
@@ -21,7 +21,7 @@ memcpy (void *dst_, const void *src_, size_t size)
 /* Copies SIZE bytes from SRC to DST, which are allowed to
    overlap.  Returns DST. */
 void *
-memmove (void *dst_, const void *src_, size_t size) 
+memmove (void *dst_, const void *src_, size_t size)
 {
   unsigned char *dst = dst_;
   const unsigned char *src = src_;
@@ -29,12 +29,12 @@ memmove (void *dst_, const void *src_, size_t size)
   ASSERT (dst != NULL || size == 0);
   ASSERT (src != NULL || size == 0);
 
-  if (dst < src) 
+  if (dst < src)
     {
       while (size-- > 0)
         *dst++ = *src++;
     }
-  else 
+  else
     {
       dst += size;
       src += size;
@@ -50,7 +50,7 @@ memmove (void *dst_, const void *src_, size_t size)
    greater, a negative value if the byte in B is greater, or zero
    if blocks A and B are equal. */
 int
-memcmp (const void *a_, const void *b_, size_t size) 
+memcmp (const void *a_, const void *b_, size_t size)
 {
   const unsigned char *a = a_;
   const unsigned char *b = b_;
@@ -70,7 +70,7 @@ memcmp (const void *a_, const void *b_, size_t size)
    an unsigned char) is greater, or zero if strings A and B are
    equal. */
 int
-strcmp (const char *a_, const char *b_) 
+strcmp (const char *a_, const char *b_)
 {
   const unsigned char *a = (const unsigned char *) a_;
   const unsigned char *b = (const unsigned char *) b_;
@@ -78,7 +78,7 @@ strcmp (const char *a_, const char *b_)
   ASSERT (a != NULL);
   ASSERT (b != NULL);
 
-  while (*a != '\0' && *a == *b) 
+  while (*a != '\0' && *a == *b)
     {
       a++;
       b++;
@@ -91,7 +91,7 @@ strcmp (const char *a_, const char *b_)
    SIZE bytes starting at BLOCK.  Returns a null pointer if CH
    does not occur in BLOCK. */
 void *
-memchr (const void *block_, int ch_, size_t size) 
+memchr (const void *block_, int ch_, size_t size)
 {
   const unsigned char *block = block_;
   unsigned char ch = ch_;
@@ -110,13 +110,13 @@ memchr (const void *block_, int ch_, size_t size)
    then returns a pointer to the null terminator at the end of
    STRING. */
 char *
-strchr (const char *string, int c_) 
+strchr (const char *string, int c_)
 {
   char c = c_;
 
   ASSERT (string != NULL);
 
-  for (;;) 
+  for (;;)
     if (*string == c)
       return (char *) string;
     else if (*string == '\0')
@@ -128,7 +128,7 @@ strchr (const char *string, int c_)
 /* Returns the length of the initial substring of STRING that
    consists of characters that are not in STOP. */
 size_t
-strcspn (const char *string, const char *stop) 
+strcspn (const char *string, const char *stop)
 {
   size_t length;
 
@@ -142,7 +142,7 @@ strcspn (const char *string, const char *stop)
    also in STOP.  If no character in STRING is in STOP, returns a
    null pointer. */
 char *
-strpbrk (const char *string, const char *stop) 
+strpbrk (const char *string, const char *stop)
 {
   for (; *string != '\0'; string++)
     if (strchr (stop, *string) != NULL)
@@ -153,7 +153,7 @@ strpbrk (const char *string, const char *stop)
 /* Returns a pointer to the last occurrence of C in STRING.
    Returns a null pointer if C does not occur in STRING. */
 char *
-strrchr (const char *string, int c_) 
+strrchr (const char *string, int c_)
 {
   char c = c_;
   const char *p = NULL;
@@ -167,10 +167,10 @@ strrchr (const char *string, int c_)
 /* Returns the length of the initial substring of STRING that
    consists of characters in SKIP. */
 size_t
-strspn (const char *string, const char *skip) 
+strspn (const char *string, const char *skip)
 {
   size_t length;
-  
+
   for (length = 0; string[length] != '\0'; length++)
     if (strchr (skip, string[length]) == NULL)
       break;
@@ -181,12 +181,12 @@ strspn (const char *string, const char *skip)
    HAYSTACK.  Returns a null pointer if NEEDLE does not exist
    within HAYSTACK. */
 char *
-strstr (const char *haystack, const char *needle) 
+strstr (const char *haystack, const char *needle)
 {
   size_t haystack_len = strlen (haystack);
   size_t needle_len = strlen (needle);
 
-  if (haystack_len >= needle_len) 
+  if (haystack_len >= needle_len)
     {
       size_t i;
 
@@ -232,10 +232,10 @@ strstr (const char *haystack, const char *needle)
      'tokenize.'
 */
 char *
-strtok_r (char *s, const char *delimiters, char **save_ptr) 
+strtok_r (char *s, const char *delimiters, char **save_ptr)
 {
   char *token;
-  
+
   ASSERT (delimiters != NULL);
   ASSERT (save_ptr != NULL);
 
@@ -246,7 +246,7 @@ strtok_r (char *s, const char *delimiters, char **save_ptr)
   ASSERT (s != NULL);
 
   /* Skip any DELIMITERS at our current position. */
-  while (strchr (delimiters, *s) != NULL) 
+  while (strchr (delimiters, *s) != NULL)
     {
       /* strchr() will always return nonnull if we're searching
          for a null byte, because every string contains a null
@@ -264,24 +264,24 @@ strtok_r (char *s, const char *delimiters, char **save_ptr)
   token = s;
   while (strchr (delimiters, *s) == NULL)
     s++;
-  if (*s != '\0') 
+  if (*s != '\0')
     {
       *s = '\0';
       *save_ptr = s + 1;
     }
-  else 
+  else
     *save_ptr = s;
   return token;
 }
 
 /* Sets the SIZE bytes in DST to VALUE. */
 void *
-memset (void *dst_, int value, size_t size) 
+memset (void *dst_, int value, size_t size)
 {
   unsigned char *dst = dst_;
 
   ASSERT (dst != NULL || size == 0);
-  
+
   while (size-- > 0)
     *dst++ = value;
 
@@ -290,7 +290,7 @@ memset (void *dst_, int value, size_t size)
 
 /* Returns the length of STRING. */
 size_t
-strlen (const char *string) 
+strlen (const char *string)
 {
   const char *p;
 
@@ -304,7 +304,7 @@ strlen (const char *string)
 /* If STRING is less than MAXLEN characters in length, returns
    its actual length.  Otherwise, returns MAXLEN. */
 size_t
-strnlen (const char *string, size_t maxlen) 
+strnlen (const char *string, size_t maxlen)
 {
   size_t length;
 
@@ -323,7 +323,7 @@ strnlen (const char *string, size_t maxlen)
    http://www.courtesan.com/todd/papers/strlcpy.html for
    information on strlcpy(). */
 size_t
-strlcpy (char *dst, const char *src, size_t size) 
+strlcpy (char *dst, const char *src, size_t size)
 {
   size_t src_len;
 
@@ -331,7 +331,7 @@ strlcpy (char *dst, const char *src, size_t size)
   ASSERT (src != NULL);
 
   src_len = strlen (src);
-  if (size > 0) 
+  if (size > 0)
     {
       size_t dst_len = size - 1;
       if (src_len < dst_len)
@@ -353,7 +353,7 @@ strlcpy (char *dst, const char *src, size_t size)
    http://www.courtesan.com/todd/papers/strlcpy.html for
    information on strlcpy(). */
 size_t
-strlcat (char *dst, const char *src, size_t size) 
+strlcat (char *dst, const char *src, size_t size)
 {
   size_t src_len, dst_len;
 
@@ -362,7 +362,7 @@ strlcat (char *dst, const char *src, size_t size)
 
   src_len = strlen (src);
   dst_len = strlen (dst);
-  if (size > 0 && dst_len < size) 
+  if (size > 0 && dst_len < size)
     {
       size_t copy_cnt = size - dst_len - 1;
       if (src_len < copy_cnt)

--- a/pintos/src/lib/syscall-nr.h
+++ b/pintos/src/lib/syscall-nr.h
@@ -2,7 +2,7 @@
 #define __LIB_SYSCALL_NR_H
 
 /* System call numbers. */
-enum 
+enum
   {
     /* Projects 2 and later. */
     SYS_HALT,                   /* Halt the operating system. */

--- a/pintos/src/lib/user/console.c
+++ b/pintos/src/lib/user/console.c
@@ -6,14 +6,14 @@
 /* The standard vprintf() function,
    which is like printf() but uses a va_list. */
 int
-vprintf (const char *format, va_list args) 
+vprintf (const char *format, va_list args)
 {
   return vhprintf (STDOUT_FILENO, format, args);
 }
 
 /* Like printf(), but writes output to the given HANDLE. */
 int
-hprintf (int handle, const char *format, ...) 
+hprintf (int handle, const char *format, ...)
 {
   va_list args;
   int retval;
@@ -28,7 +28,7 @@ hprintf (int handle, const char *format, ...)
 /* Writes string S to the console, followed by a new-line
    character. */
 int
-puts (const char *s) 
+puts (const char *s)
 {
   write (STDOUT_FILENO, s, strlen (s));
   putchar ('\n');
@@ -38,15 +38,15 @@ puts (const char *s)
 
 /* Writes C to the console. */
 int
-putchar (int c) 
+putchar (int c)
 {
   char c2 = c;
   write (STDOUT_FILENO, &c2, 1);
   return c;
 }
-
+
 /* Auxiliary data for vhprintf_helper(). */
-struct vhprintf_aux 
+struct vhprintf_aux
   {
     char buf[64];       /* Character buffer. */
     char *p;            /* Current position in buffer. */
@@ -61,7 +61,7 @@ static void flush (struct vhprintf_aux *);
    arguments given in ARGS and writes the output to the given
    HANDLE. */
 int
-vhprintf (int handle, const char *format, va_list args) 
+vhprintf (int handle, const char *format, va_list args)
 {
   struct vhprintf_aux aux;
   aux.p = aux.buf;
@@ -75,7 +75,7 @@ vhprintf (int handle, const char *format, va_list args)
 /* Adds C to the buffer in AUX, flushing it if the buffer fills
    up. */
 static void
-add_char (char c, void *aux_) 
+add_char (char c, void *aux_)
 {
   struct vhprintf_aux *aux = aux_;
   *aux->p++ = c;

--- a/pintos/src/lib/user/debug.c
+++ b/pintos/src/lib/user/debug.c
@@ -20,6 +20,6 @@ debug_panic (const char *file, int line, const char *function,
   va_end (args);
 
   debug_backtrace ();
-  
+
   exit (1);
 }

--- a/pintos/src/lib/user/entry.c
+++ b/pintos/src/lib/user/entry.c
@@ -4,7 +4,7 @@ int main (int, char *[]);
 void _start (int argc, char *argv[]);
 
 void
-_start (int argc, char *argv[]) 
+_start (int argc, char *argv[])
 {
   exit (main (argc, argv));
 }

--- a/pintos/src/lib/user/syscall.c
+++ b/pintos/src/lib/user/syscall.c
@@ -68,7 +68,7 @@ practice (int i)
 }
 
 void
-halt (void) 
+halt (void)
 {
   syscall0 (SYS_HALT);
   NOT_REACHED ();
@@ -112,7 +112,7 @@ open (const char *file)
 }
 
 int
-filesize (int fd) 
+filesize (int fd)
 {
   return syscall1 (SYS_FILESIZE, fd);
 }
@@ -130,13 +130,13 @@ write (int fd, const void *buffer, unsigned size)
 }
 
 void
-seek (int fd, unsigned position) 
+seek (int fd, unsigned position)
 {
   syscall2 (SYS_SEEK, fd, position);
 }
 
 unsigned
-tell (int fd) 
+tell (int fd)
 {
   return syscall1 (SYS_TELL, fd);
 }
@@ -172,19 +172,19 @@ mkdir (const char *dir)
 }
 
 bool
-readdir (int fd, char name[READDIR_MAX_LEN + 1]) 
+readdir (int fd, char name[READDIR_MAX_LEN + 1])
 {
   return syscall2 (SYS_READDIR, fd, name);
 }
 
 bool
-isdir (int fd) 
+isdir (int fd)
 {
   return syscall1 (SYS_ISDIR, fd);
 }
 
 int
-inumber (int fd) 
+inumber (int fd)
 {
   return syscall1 (SYS_INUMBER, fd);
 }

--- a/pintos/src/tests/cksum.c
+++ b/pintos/src/tests/cksum.c
@@ -82,7 +82,7 @@ cksum (const void *b_, size_t n)
 #ifdef STANDALONE_TEST
 #include <stdio.h>
 int
-main (void) 
+main (void)
 {
   char buf[65536];
   int n = fread (buf, 1, sizeof buf, stdin);

--- a/pintos/src/tests/filesys/base/child-syn-read.c
+++ b/pintos/src/tests/filesys/base/child-syn-read.c
@@ -16,14 +16,14 @@ const char *test_name = "child-syn-read";
 static char buf[BUF_SIZE];
 
 int
-main (int argc, const char *argv[]) 
+main (int argc, const char *argv[])
 {
   int child_idx;
   int fd;
   size_t i;
 
   quiet = true;
-  
+
   CHECK (argc == 2, "argc must be 2, actually %d", argc);
   child_idx = atoi (argv[1]);
 
@@ -31,7 +31,7 @@ main (int argc, const char *argv[])
   random_bytes (buf, sizeof buf);
 
   CHECK ((fd = open (file_name)) > 1, "open \"%s\"", file_name);
-  for (i = 0; i < sizeof buf; i++) 
+  for (i = 0; i < sizeof buf; i++)
     {
       char c;
       CHECK (read (fd, &c, 1) > 0, "read \"%s\"", file_name);

--- a/pintos/src/tests/filesys/base/child-syn-wrt.c
+++ b/pintos/src/tests/filesys/base/child-syn-wrt.c
@@ -17,7 +17,7 @@ main (int argc, char *argv[])
   int fd;
 
   quiet = true;
-  
+
   CHECK (argc == 2, "argc must be 2, actually %d", argc);
   child_idx = atoi (argv[1]);
 

--- a/pintos/src/tests/filesys/base/syn-read.c
+++ b/pintos/src/tests/filesys/base/syn-read.c
@@ -14,7 +14,7 @@ static char buf[BUF_SIZE];
 #define CHILD_CNT 10
 
 void
-test_main (void) 
+test_main (void)
 {
   pid_t children[CHILD_CNT];
   int fd;

--- a/pintos/src/tests/filesys/base/syn-remove.c
+++ b/pintos/src/tests/filesys/base/syn-remove.c
@@ -11,11 +11,11 @@ char buf1[1234];
 char buf2[1234];
 
 void
-test_main (void) 
+test_main (void)
 {
   const char *file_name = "deleteme";
   int fd;
-  
+
   CHECK (create (file_name, sizeof buf1), "create \"%s\"", file_name);
   CHECK ((fd = open (file_name)) > 1, "open \"%s\"", file_name);
   CHECK (remove (file_name), "remove \"%s\"", file_name);

--- a/pintos/src/tests/filesys/base/syn-write.c
+++ b/pintos/src/tests/filesys/base/syn-write.c
@@ -14,7 +14,7 @@ char buf1[BUF_SIZE];
 char buf2[BUF_SIZE];
 
 void
-test_main (void) 
+test_main (void)
 {
   pid_t children[CHILD_CNT];
   int fd;

--- a/pintos/src/tests/filesys/extended/child-syn-rw.c
+++ b/pintos/src/tests/filesys/extended/child-syn-rw.c
@@ -19,14 +19,14 @@ static char buf1[BUF_SIZE];
 static char buf2[BUF_SIZE];
 
 int
-main (int argc, const char *argv[]) 
+main (int argc, const char *argv[])
 {
   int child_idx;
   int fd;
   size_t ofs;
 
   quiet = true;
-  
+
   CHECK (argc == 2, "argc must be 2, actually %d", argc);
   child_idx = atoi (argv[1]);
 
@@ -41,7 +41,7 @@ main (int argc, const char *argv[])
       CHECK (bytes_read >= -1 && bytes_read <= (int) (sizeof buf2 - ofs),
              "%zu-byte read on \"%s\" returned invalid value of %d",
              sizeof buf2 - ofs, file_name, bytes_read);
-      if (bytes_read > 0) 
+      if (bytes_read > 0)
         {
           compare_bytes (buf2 + ofs, buf1 + ofs, bytes_read, ofs, file_name);
           ofs += bytes_read;

--- a/pintos/src/tests/filesys/extended/dir-empty-name.c
+++ b/pintos/src/tests/filesys/extended/dir-empty-name.c
@@ -6,7 +6,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   CHECK (!mkdir (""), "mkdir \"\" (must return false)");
 }

--- a/pintos/src/tests/filesys/extended/dir-mk-tree.c
+++ b/pintos/src/tests/filesys/extended/dir-mk-tree.c
@@ -5,7 +5,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   make_tree (4, 3, 3, 4);
 }

--- a/pintos/src/tests/filesys/extended/dir-mkdir.c
+++ b/pintos/src/tests/filesys/extended/dir-mkdir.c
@@ -5,7 +5,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   CHECK (mkdir ("a"), "mkdir \"a\"");
   CHECK (create ("a/b", 512), "create \"a/b\"");

--- a/pintos/src/tests/filesys/extended/dir-open.c
+++ b/pintos/src/tests/filesys/extended/dir-open.c
@@ -6,11 +6,11 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   int fd;
   int retval;
-  
+
   CHECK (mkdir ("xyzzy"), "mkdir \"xyzzy\"");
   CHECK ((fd = open ("xyzzy")) > 1, "open \"xyzzy\"");
 

--- a/pintos/src/tests/filesys/extended/dir-over-file.c
+++ b/pintos/src/tests/filesys/extended/dir-over-file.c
@@ -6,7 +6,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   CHECK (mkdir ("abc"), "mkdir \"abc\"");
   CHECK (!create ("abc", 0), "create \"abc\" (must return false)");

--- a/pintos/src/tests/filesys/extended/dir-rm-cwd.c
+++ b/pintos/src/tests/filesys/extended/dir-rm-cwd.c
@@ -7,7 +7,7 @@
 #include "tests/main.h"
 
 static int
-wrap_open (const char *name) 
+wrap_open (const char *name)
 {
   static int fds[8], fd_cnt;
   int fd, i;
@@ -21,7 +21,7 @@ wrap_open (const char *name)
 }
 
 void
-test_main (void) 
+test_main (void)
 {
   int root_fd, a_fd0;
   char name[READDIR_MAX_LEN + 1];

--- a/pintos/src/tests/filesys/extended/dir-rm-parent.c
+++ b/pintos/src/tests/filesys/extended/dir-rm-parent.c
@@ -6,7 +6,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   CHECK (mkdir ("a"), "mkdir \"a\"");
   CHECK (chdir ("a"), "chdir \"a\"");

--- a/pintos/src/tests/filesys/extended/dir-rm-root.c
+++ b/pintos/src/tests/filesys/extended/dir-rm-root.c
@@ -6,7 +6,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   CHECK (!remove ("/"), "remove \"/\" (must fail)");
   CHECK (create ("/a", 243), "create \"/a\"");

--- a/pintos/src/tests/filesys/extended/dir-rm-tree.c
+++ b/pintos/src/tests/filesys/extended/dir-rm-tree.c
@@ -11,7 +11,7 @@
 static void remove_tree (int at, int bt, int ct, int dt);
 
 void
-test_main (void) 
+test_main (void)
 {
   make_tree (4, 3, 3, 4);
   remove_tree (4, 3, 3, 4);
@@ -20,7 +20,7 @@ test_main (void)
 static void do_remove (const char *format, ...) PRINTF_FORMAT (1, 2);
 
 static void
-remove_tree (int at, int bt, int ct, int dt) 
+remove_tree (int at, int bt, int ct, int dt)
 {
   char try[128];
   int a, b, c, d;
@@ -28,11 +28,11 @@ remove_tree (int at, int bt, int ct, int dt)
   msg ("removing /0/0/0/0 through /%d/%d/%d/%d...",
        at - 1, bt - 1, ct - 1, dt - 1);
   quiet = true;
-  for (a = 0; a < at; a++) 
+  for (a = 0; a < at; a++)
     {
-      for (b = 0; b < bt; b++) 
+      for (b = 0; b < bt; b++)
         {
-          for (c = 0; c < ct; c++) 
+          for (c = 0; c < ct; c++)
             {
               for (d = 0; d < dt; d++)
                 do_remove ("/%d/%d/%d/%d", a, b, c, d);
@@ -49,7 +49,7 @@ remove_tree (int at, int bt, int ct, int dt)
 }
 
 static void
-do_remove (const char *format, ...) 
+do_remove (const char *format, ...)
 {
   char name[128];
   va_list args;

--- a/pintos/src/tests/filesys/extended/dir-rmdir.c
+++ b/pintos/src/tests/filesys/extended/dir-rmdir.c
@@ -6,7 +6,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   CHECK (mkdir ("a"), "mkdir \"a\"");
   CHECK (remove ("a"), "rmdir \"a\"");

--- a/pintos/src/tests/filesys/extended/dir-under-file.c
+++ b/pintos/src/tests/filesys/extended/dir-under-file.c
@@ -6,7 +6,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   CHECK (create ("abc", 0), "create \"abc\"");
   CHECK (!mkdir ("abc"), "mkdir \"abc\" (must return false)");

--- a/pintos/src/tests/filesys/extended/dir-vine.c
+++ b/pintos/src/tests/filesys/extended/dir-vine.c
@@ -1,7 +1,7 @@
 /* Create a very deep "vine" of directories: /dir0/dir1/dir2/...
    and an ordinary file in each of them, until we fill up the
    disk.
-   
+
    Then delete most of them, for two reasons.  First, "tar"
    limits file names to 100 characters (which could be extended
    to 256 without much trouble).  Second, a full disk has no room
@@ -14,7 +14,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   int i;
 
@@ -22,7 +22,7 @@ test_main (void)
   quiet = true;
   CHECK (mkdir ("start"), "mkdir \"start\"");
   CHECK (chdir ("start"), "chdir \"start\"");
-  for (i = 0; ; i++) 
+  for (i = 0; ; i++)
     {
       char name[3][READDIR_MAX_LEN + 1];
       char file_name[16], dir_name[16];
@@ -35,20 +35,20 @@ test_main (void)
         break;
       CHECK ((fd = open (file_name)) > 1, "open \"%s\"", file_name);
       snprintf (contents, sizeof contents, "contents %d\n", i);
-      if (write (fd, contents, strlen (contents)) != (int) strlen (contents)) 
+      if (write (fd, contents, strlen (contents)) != (int) strlen (contents))
         {
           CHECK (remove (file_name), "remove \"%s\"", file_name);
           close (fd);
           break;
         }
       close (fd);
-      
+
       /* Create directory. */
       snprintf (dir_name, sizeof dir_name, "dir%d", i);
-      if (!mkdir (dir_name)) 
+      if (!mkdir (dir_name))
         {
           CHECK (remove (file_name), "remove \"%s\"", file_name);
-          break; 
+          break;
         }
 
       /* Check for file and directory. */
@@ -71,7 +71,7 @@ test_main (void)
 
   msg ("removing all but top 10 levels of files and directories...");
   quiet = true;
-  while (i-- > 10) 
+  while (i-- > 10)
     {
       char file_name[16], dir_name[16];
 

--- a/pintos/src/tests/filesys/extended/grow-file-size.c
+++ b/pintos/src/tests/filesys/extended/grow-file-size.c
@@ -10,13 +10,13 @@
 static char buf[2134];
 
 static size_t
-return_block_size (void) 
+return_block_size (void)
 {
   return 37;
 }
 
 static void
-check_file_size (int fd, long ofs) 
+check_file_size (int fd, long ofs)
 {
   long size = filesize (fd);
   if (size != ofs)
@@ -25,7 +25,7 @@ check_file_size (int fd, long ofs)
 }
 
 void
-test_main (void) 
+test_main (void)
 {
   seq_test ("testfile",
             buf, sizeof buf, 0,

--- a/pintos/src/tests/filesys/extended/grow-sparse.c
+++ b/pintos/src/tests/filesys/extended/grow-sparse.c
@@ -8,12 +8,12 @@
 static char buf[76543];
 
 void
-test_main (void) 
+test_main (void)
 {
   const char *file_name = "testfile";
   char zero = 0;
   int fd;
-  
+
   CHECK (create (file_name, 0), "create \"%s\"", file_name);
   CHECK ((fd = open (file_name)) > 1, "open \"%s\"", file_name);
   msg ("seek \"%s\"", file_name);

--- a/pintos/src/tests/filesys/extended/grow-tell.c
+++ b/pintos/src/tests/filesys/extended/grow-tell.c
@@ -9,13 +9,13 @@
 static char buf[2134];
 
 static size_t
-return_block_size (void) 
+return_block_size (void)
 {
   return 37;
 }
 
 static void
-check_tell (int fd, long ofs) 
+check_tell (int fd, long ofs)
 {
   long pos = tell (fd);
   if (pos != ofs)
@@ -24,7 +24,7 @@ check_tell (int fd, long ofs)
 }
 
 void
-test_main (void) 
+test_main (void)
 {
   seq_test ("foobar",
             buf, sizeof buf, 0,

--- a/pintos/src/tests/filesys/extended/grow-two-files.c
+++ b/pintos/src/tests/filesys/extended/grow-two-files.c
@@ -11,9 +11,9 @@ static char buf_a[FILE_SIZE];
 static char buf_b[FILE_SIZE];
 
 static void
-write_some_bytes (const char *file_name, int fd, const char *buf, size_t *ofs) 
+write_some_bytes (const char *file_name, int fd, const char *buf, size_t *ofs)
 {
-  if (*ofs < FILE_SIZE) 
+  if (*ofs < FILE_SIZE)
     {
       size_t block_size = random_ulong () % (FILE_SIZE / 8) + 1;
       size_t ret_val;
@@ -29,7 +29,7 @@ write_some_bytes (const char *file_name, int fd, const char *buf, size_t *ofs)
 }
 
 void
-test_main (void) 
+test_main (void)
 {
   int fd_a, fd_b;
   size_t ofs_a = 0, ofs_b = 0;
@@ -45,7 +45,7 @@ test_main (void)
   CHECK ((fd_b = open ("b")) > 1, "open \"b\"");
 
   msg ("write \"a\" and \"b\" alternately");
-  while (ofs_a < FILE_SIZE || ofs_b < FILE_SIZE) 
+  while (ofs_a < FILE_SIZE || ofs_b < FILE_SIZE)
     {
       write_some_bytes ("a", fd_a, buf_a, &ofs_a);
       write_some_bytes ("b", fd_b, buf_b, &ofs_b);

--- a/pintos/src/tests/filesys/extended/mk-tree.c
+++ b/pintos/src/tests/filesys/extended/mk-tree.c
@@ -9,7 +9,7 @@ static void do_mkdir (const char *format, ...) PRINTF_FORMAT (1, 2);
 static void do_touch (const char *format, ...) PRINTF_FORMAT (1, 2);
 
 void
-make_tree (int at, int bt, int ct, int dt) 
+make_tree (int at, int bt, int ct, int dt)
 {
   char try[128];
   int a, b, c, d;
@@ -18,13 +18,13 @@ make_tree (int at, int bt, int ct, int dt)
   msg ("creating /0/0/0/0 through /%d/%d/%d/%d...",
        at - 1, bt - 1, ct - 1, dt - 1);
   quiet = true;
-  for (a = 0; a < at; a++) 
+  for (a = 0; a < at; a++)
     {
       do_mkdir ("/%d", a);
-      for (b = 0; b < bt; b++) 
+      for (b = 0; b < bt; b++)
         {
           do_mkdir ("/%d/%d", a, b);
-          for (c = 0; c < ct; c++) 
+          for (c = 0; c < ct; c++)
             {
               do_mkdir ("/%d/%d/%d", a, b, c);
               for (d = 0; d < dt; d++)
@@ -41,7 +41,7 @@ make_tree (int at, int bt, int ct, int dt)
 }
 
 static void
-do_mkdir (const char *format, ...) 
+do_mkdir (const char *format, ...)
 {
   char dir[128];
   va_list args;

--- a/pintos/src/tests/filesys/extended/syn-rw.c
+++ b/pintos/src/tests/filesys/extended/syn-rw.c
@@ -12,7 +12,7 @@ char buf[BUF_SIZE];
 #define CHILD_CNT 4
 
 void
-test_main (void) 
+test_main (void)
 {
   pid_t children[CHILD_CNT];
   size_t ofs;

--- a/pintos/src/tests/filesys/extended/tar.c
+++ b/pintos/src/tests/filesys/extended/tar.c
@@ -12,7 +12,7 @@ static bool make_tar_archive (const char *archive_name,
                               char *files[], size_t file_cnt);
 
 int
-main (int argc, char *argv[]) 
+main (int argc, char *argv[])
 {
   if (argc < 3)
     usage ();
@@ -22,7 +22,7 @@ main (int argc, char *argv[])
 }
 
 static void
-usage (void) 
+usage (void)
 {
   printf ("tar, tar archive creator\n"
           "Usage: tar ARCHIVE FILE...\n"
@@ -32,7 +32,7 @@ usage (void)
           "is in a directory to be archived.)\n");
   exit (EXIT_FAILURE);
 }
-
+
 static bool archive_file (char file_name[], size_t file_name_size,
                           int archive_fd, bool *write_error);
 
@@ -46,15 +46,15 @@ static bool write_header (const char *file_name, enum ustar_type, int size,
 static bool do_write (int fd, const char *buffer, int size, bool *write_error);
 
 static bool
-make_tar_archive (const char *archive_name, char *files[], size_t file_cnt) 
+make_tar_archive (const char *archive_name, char *files[], size_t file_cnt)
 {
   static const char zeros[512];
   int archive_fd;
   bool success = true;
   bool write_error = false;
   size_t i;
-  
-  if (!create (archive_name, 0)) 
+
+  if (!create (archive_name, 0))
     {
       printf ("%s: create failed\n", archive_name);
       return false;
@@ -66,10 +66,10 @@ make_tar_archive (const char *archive_name, char *files[], size_t file_cnt)
       return false;
     }
 
-  for (i = 0; i < file_cnt; i++) 
+  for (i = 0; i < file_cnt; i++)
     {
       char file_name[128];
-      
+
       strlcpy (file_name, files[i], sizeof file_name);
       if (!archive_file (file_name, sizeof file_name,
                          archive_fd, &write_error))
@@ -77,7 +77,7 @@ make_tar_archive (const char *archive_name, char *files[], size_t file_cnt)
     }
 
   if (!do_write (archive_fd, zeros, 512, &write_error)
-      || !do_write (archive_fd, zeros, 512, &write_error)) 
+      || !do_write (archive_fd, zeros, 512, &write_error))
     success = false;
 
   close (archive_fd);
@@ -87,28 +87,28 @@ make_tar_archive (const char *archive_name, char *files[], size_t file_cnt)
 
 static bool
 archive_file (char file_name[], size_t file_name_size,
-              int archive_fd, bool *write_error) 
+              int archive_fd, bool *write_error)
 {
   int file_fd = open (file_name);
-  if (file_fd >= 0) 
+  if (file_fd >= 0)
     {
       bool success;
 
-      if (inumber (file_fd) != inumber (archive_fd)) 
+      if (inumber (file_fd) != inumber (archive_fd))
         {
           if (!isdir (file_fd))
             success = archive_ordinary_file (file_name, file_fd,
                                              archive_fd, write_error);
           else
             success = archive_directory (file_name, file_name_size, file_fd,
-                                         archive_fd, write_error);      
+                                         archive_fd, write_error);
         }
       else
         {
           /* Nothing to do: don't try to archive the archive file. */
           success = true;
         }
-  
+
       close (file_fd);
 
       return success;
@@ -132,14 +132,14 @@ archive_ordinary_file (const char *file_name, int file_fd,
                      archive_fd, write_error))
     return false;
 
-  while (file_size > 0) 
+  while (file_size > 0)
     {
       static char buf[512];
       int chunk_size = file_size > 512 ? 512 : file_size;
       int read_retval = read (file_fd, buf, chunk_size);
       int bytes_read = read_retval > 0 ? read_retval : 0;
 
-      if (bytes_read != chunk_size && !read_error) 
+      if (bytes_read != chunk_size && !read_error)
         {
           printf ("%s: read error\n", file_name);
           read_error = true;
@@ -164,7 +164,7 @@ archive_directory (char file_name[], size_t file_name_size, int file_fd,
   bool success = true;
 
   dir_len = strlen (file_name);
-  if (dir_len + 1 + READDIR_MAX_LEN + 1 > file_name_size) 
+  if (dir_len + 1 + READDIR_MAX_LEN + 1 > file_name_size)
     {
       printf ("%s: file name too long\n", file_name);
       return false;
@@ -172,9 +172,9 @@ archive_directory (char file_name[], size_t file_name_size, int file_fd,
 
   if (!write_header (file_name, USTAR_DIRECTORY, 0, archive_fd, write_error))
     return false;
-      
+
   file_name[dir_len] = '/';
-  while (readdir (file_fd, &file_name[dir_len + 1])) 
+  while (readdir (file_fd, &file_name[dir_len + 1]))
     if (!archive_file (file_name, file_name_size, archive_fd, write_error))
       success = false;
   file_name[dir_len] = '\0';
@@ -184,7 +184,7 @@ archive_directory (char file_name[], size_t file_name_size, int file_fd,
 
 static bool
 write_header (const char *file_name, enum ustar_type type, int size,
-              int archive_fd, bool *write_error) 
+              int archive_fd, bool *write_error)
 {
   static char header[512];
   return (ustar_make_header (file_name, type, size, header)
@@ -192,17 +192,17 @@ write_header (const char *file_name, enum ustar_type type, int size,
 }
 
 static bool
-do_write (int fd, const char *buffer, int size, bool *write_error) 
+do_write (int fd, const char *buffer, int size, bool *write_error)
 {
-  if (write (fd, buffer, size) == size) 
+  if (write (fd, buffer, size) == size)
     return true;
   else
     {
-      if (!*write_error) 
+      if (!*write_error)
         {
           printf ("error writing archive\n");
-          *write_error = true; 
+          *write_error = true;
         }
-      return false; 
+      return false;
     }
 }

--- a/pintos/src/tests/filesys/seq-test.c
+++ b/pintos/src/tests/filesys/seq-test.c
@@ -3,21 +3,21 @@
 #include <syscall.h>
 #include "tests/lib.h"
 
-void 
+void
 seq_test (const char *file_name, void *buf, size_t size, size_t initial_size,
           size_t (*block_size_func) (void),
-          void (*check_func) (int fd, long ofs)) 
+          void (*check_func) (int fd, long ofs))
 {
   size_t ofs;
   int fd;
-  
+
   random_bytes (buf, size);
   CHECK (create (file_name, initial_size), "create \"%s\"", file_name);
   CHECK ((fd = open (file_name)) > 1, "open \"%s\"", file_name);
 
   ofs = 0;
   msg ("writing \"%s\"", file_name);
-  while (ofs < size) 
+  while (ofs < size)
     {
       size_t block_size = block_size_func ();
       if (block_size > size - ofs)

--- a/pintos/src/tests/internal/list.c
+++ b/pintos/src/tests/internal/list.c
@@ -19,7 +19,7 @@
 #define MAX_SIZE 64
 
 /* A linked list element. */
-struct value 
+struct value
   {
     struct list_elem elem;      /* List element. */
     int value;                  /* Item value. */
@@ -33,17 +33,17 @@ static void verify_list_bkwd (struct list *, int size);
 
 /* Test the linked list implementation. */
 void
-test (void) 
+test (void)
 {
   int size;
 
   printf ("testing various size lists:");
-  for (size = 0; size < MAX_SIZE; size++) 
+  for (size = 0; size < MAX_SIZE; size++)
     {
       int repeat;
 
       printf (" %d", size);
-      for (repeat = 0; repeat < 10; repeat++) 
+      for (repeat = 0; repeat < 10; repeat++)
         {
           static struct value values[MAX_SIZE * 4];
           struct list list;
@@ -54,7 +54,7 @@ test (void)
           for (i = 0; i < size; i++)
             values[i].value = i;
           shuffle (values, size);
-  
+
           /* Assemble list. */
           list_init (&list);
           for (i = 0; i < size; i++)
@@ -92,7 +92,7 @@ test (void)
             {
               struct value *v = list_entry (e, struct value, elem);
               int copies = random_ulong () % 4;
-              while (copies-- > 0) 
+              while (copies-- > 0)
                 {
                   values[ofs].value = v->value;
                   list_insert (e, &values[ofs++].elem);
@@ -103,14 +103,14 @@ test (void)
           verify_list_fwd (&list, size);
         }
     }
-  
+
   printf (" done\n");
   printf ("list: PASS\n");
 }
 
 /* Shuffles the CNT elements in ARRAY into random order. */
 static void
-shuffle (struct value *array, size_t cnt) 
+shuffle (struct value *array, size_t cnt)
 {
   size_t i;
 
@@ -127,25 +127,25 @@ shuffle (struct value *array, size_t cnt)
    otherwise. */
 static bool
 value_less (const struct list_elem *a_, const struct list_elem *b_,
-            void *aux UNUSED) 
+            void *aux UNUSED)
 {
   const struct value *a = list_entry (a_, struct value, elem);
   const struct value *b = list_entry (b_, struct value, elem);
-  
+
   return a->value < b->value;
 }
 
 /* Verifies that LIST contains the values 0...SIZE when traversed
    in forward order. */
 static void
-verify_list_fwd (struct list *list, int size) 
+verify_list_fwd (struct list *list, int size)
 {
   struct list_elem *e;
   int i;
-  
+
   for (i = 0, e = list_begin (list);
        i < size && e != list_end (list);
-       i++, e = list_next (e)) 
+       i++, e = list_next (e))
     {
       struct value *v = list_entry (e, struct value, elem);
       ASSERT (i == v->value);
@@ -157,14 +157,14 @@ verify_list_fwd (struct list *list, int size)
 /* Verifies that LIST contains the values 0...SIZE when traversed
    in reverse order. */
 static void
-verify_list_bkwd (struct list *list, int size) 
+verify_list_bkwd (struct list *list, int size)
 {
   struct list_elem *e;
   int i;
 
   for (i = 0, e = list_rbegin (list);
        i < size && e != list_rend (list);
-       i++, e = list_prev (e)) 
+       i++, e = list_prev (e))
     {
       struct value *v = list_entry (e, struct value, elem);
       ASSERT (i == v->value);

--- a/pintos/src/tests/internal/stdio.c
+++ b/pintos/src/tests/internal/stdio.c
@@ -20,18 +20,18 @@
 static int failure_cnt;
 
 static void
-checkf (const char *expect, const char *format, ...) 
+checkf (const char *expect, const char *format, ...)
 {
   char output[128];
   va_list args;
 
   printf ("\"%s\" -> \"%s\": ", format, expect);
-  
+
   va_start (args, format);
   vsnprintf (output, sizeof output, format, args);
   va_end (args);
 
-  if (strcmp (expect, output)) 
+  if (strcmp (expect, output))
     {
       printf ("\nFAIL: actual output \"%s\"\n", output);
       failure_cnt++;
@@ -42,7 +42,7 @@ checkf (const char *expect, const char *format, ...)
 
 /* Test printf() implementation. */
 void
-test (void) 
+test (void)
 {
   printf ("Testing formats:");
 
@@ -89,7 +89,7 @@ test (void)
   checkf ("-12,345,678,901,234,567", "%'lld", -12345678901234567LL);
   checkf ("-123,456,789,012,345,678", "%'lld", -123456789012345678LL);
   checkf ("-1,234,567,890,123,456,789", "%'lld", -1234567890123456789LL);
-  
+
   /* Check signed integer conversions. */
   checkf ("    0", "%5d", 0);
   checkf ("0    ", "%-5d", 0);
@@ -150,7 +150,7 @@ test (void)
   checkf ("    0", "%#5x", 0);
   checkf ("    0", "%#5X", 0);
   checkf ("  00000000", "%#10.8x", 0);
-  
+
   checkf ("    1", "%5u", 1);
   checkf ("    1", "%5o", 1);
   checkf ("    1", "%5x", 1);
@@ -205,4 +205,4 @@ test (void)
     printf ("\nstdio: PASS\n");
   else
     printf ("\nstdio: FAIL: %d tests failed\n", failure_cnt);
-}                                                                  
+}

--- a/pintos/src/tests/internal/stdlib.c
+++ b/pintos/src/tests/internal/stdlib.c
@@ -25,7 +25,7 @@ static void verify_bsearch (const int[], size_t);
 
 /* Test sorting and searching implementations. */
 void
-test (void) 
+test (void)
 {
   int cnt;
 
@@ -35,7 +35,7 @@ test (void)
       int repeat;
 
       printf (" %zu", cnt);
-      for (repeat = 0; repeat < 10; repeat++) 
+      for (repeat = 0; repeat < 10; repeat++)
         {
           static int values[MAX_CNT];
           int i;
@@ -44,21 +44,21 @@ test (void)
           for (i = 0; i < cnt; i++)
             values[i] = i;
           shuffle (values, cnt);
-  
+
           /* Sort VALUES, then verify ordering. */
           qsort (values, cnt, sizeof *values, compare_ints);
           verify_order (values, cnt);
           verify_bsearch (values, cnt);
         }
     }
-  
+
   printf (" done\n");
   printf ("stdlib: PASS\n");
 }
 
 /* Shuffles the CNT elements in ARRAY into random order. */
 static void
-shuffle (int *array, size_t cnt) 
+shuffle (int *array, size_t cnt)
 {
   size_t i;
 
@@ -75,7 +75,7 @@ shuffle (int *array, size_t cnt)
    0 if *A equals *B,
    -1 if *A is less than *B. */
 static int
-compare_ints (const void *a_, const void *b_) 
+compare_ints (const void *a_, const void *b_)
 {
   const int *a = a_;
   const int *b = b_;
@@ -85,30 +85,30 @@ compare_ints (const void *a_, const void *b_)
 
 /* Verifies that ARRAY contains the CNT ints 0...CNT-1. */
 static void
-verify_order (const int *array, size_t cnt) 
+verify_order (const int *array, size_t cnt)
 {
   int i;
 
-  for (i = 0; (size_t) i < cnt; i++) 
+  for (i = 0; (size_t) i < cnt; i++)
     ASSERT (array[i] == i);
 }
 
 /* Checks that bsearch() works properly in ARRAY.  ARRAY must
    contain the values 0...CNT-1. */
 static void
-verify_bsearch (const int *array, size_t cnt) 
+verify_bsearch (const int *array, size_t cnt)
 {
   int not_in_array[] = {0, -1, INT_MAX, MAX_CNT, MAX_CNT + 1, MAX_CNT * 2};
   int i;
 
   /* Check that all the values in the array are found properly. */
-  for (i = 0; (size_t) i < cnt; i++) 
+  for (i = 0; (size_t) i < cnt; i++)
     ASSERT (bsearch (&i, array, cnt, sizeof *array, compare_ints)
             == array + i);
 
   /* Check that some values not in the array are not found. */
   not_in_array[0] = cnt;
-  for (i = 0; (size_t) i < sizeof not_in_array / sizeof *not_in_array; i++) 
+  for (i = 0; (size_t) i < sizeof not_in_array / sizeof *not_in_array; i++)
     ASSERT (bsearch (&not_in_array[i], array, cnt, sizeof *array, compare_ints)
             == NULL);
 }

--- a/pintos/src/tests/lib.c
+++ b/pintos/src/tests/lib.c
@@ -9,7 +9,7 @@ const char *test_name;
 bool quiet = false;
 
 static void
-vmsg (const char *format, va_list args, const char *suffix) 
+vmsg (const char *format, va_list args, const char *suffix)
 {
   /* We go to some trouble to stuff the entire message into a
      single buffer and output it in a single system call, because
@@ -25,7 +25,7 @@ vmsg (const char *format, va_list args, const char *suffix)
 }
 
 void
-msg (const char *format, ...) 
+msg (const char *format, ...)
 {
   va_list args;
 
@@ -37,7 +37,7 @@ msg (const char *format, ...)
 }
 
 void
-fail (const char *format, ...) 
+fail (const char *format, ...)
 {
   va_list args;
 
@@ -49,13 +49,13 @@ fail (const char *format, ...)
 }
 
 static void
-swap (void *a_, void *b_, size_t size) 
+swap (void *a_, void *b_, size_t size)
 {
   uint8_t *a = a_;
   uint8_t *b = b_;
   size_t i;
 
-  for (i = 0; i < size; i++) 
+  for (i = 0; i < size; i++)
     {
       uint8_t t = a[i];
       a[i] = b[i];
@@ -64,7 +64,7 @@ swap (void *a_, void *b_, size_t size)
 }
 
 void
-shuffle (void *buf_, size_t cnt, size_t size) 
+shuffle (void *buf_, size_t cnt, size_t size)
 {
   char *buf = buf_;
   size_t i;
@@ -77,11 +77,11 @@ shuffle (void *buf_, size_t cnt, size_t size)
 }
 
 void
-exec_children (const char *child_name, pid_t pids[], size_t child_cnt) 
+exec_children (const char *child_name, pid_t pids[], size_t child_cnt)
 {
   size_t i;
 
-  for (i = 0; i < child_cnt; i++) 
+  for (i = 0; i < child_cnt; i++)
     {
       char cmd_line[128];
       snprintf (cmd_line, sizeof cmd_line, "%s %zu", child_name, i);
@@ -91,11 +91,11 @@ exec_children (const char *child_name, pid_t pids[], size_t child_cnt)
 }
 
 void
-wait_children (pid_t pids[], size_t child_cnt) 
+wait_children (pid_t pids[], size_t child_cnt)
 {
   size_t i;
-  
-  for (i = 0; i < child_cnt; i++) 
+
+  for (i = 0; i < child_cnt; i++)
     {
       int status = wait (pids[i]);
       CHECK (status == (int) i,
@@ -106,7 +106,7 @@ wait_children (pid_t pids[], size_t child_cnt)
 
 void
 check_file_handle (int fd,
-                   const char *file_name, const void *buf_, size_t size) 
+                   const char *file_name, const void *buf_, size_t size)
 {
   const char *buf = buf_;
   size_t ofs = 0;
@@ -148,7 +148,7 @@ check_file_handle (int fd,
 }
 
 void
-check_file (const char *file_name, const void *buf, size_t size) 
+check_file (const char *file_name, const void *buf, size_t size)
 {
   int fd;
 
@@ -161,7 +161,7 @@ check_file (const char *file_name, const void *buf, size_t size)
 
 void
 compare_bytes (const void *read_data_, const void *expected_data_, size_t size,
-               size_t ofs, const char *file_name) 
+               size_t ofs, const char *file_name)
 {
   const uint8_t *read_data = read_data_;
   const uint8_t *expected_data = expected_data_;
@@ -170,7 +170,7 @@ compare_bytes (const void *read_data_, const void *expected_data_, size_t size,
 
   if (!memcmp (read_data, expected_data, size))
     return;
-  
+
   for (i = 0; i < size; i++)
     if (read_data[i] != expected_data[i])
       break;
@@ -182,7 +182,7 @@ compare_bytes (const void *read_data_, const void *expected_data_, size_t size,
   msg ("%zu bytes read starting at offset %zu in \"%s\" differ "
        "from expected.", j - i, ofs + i, file_name);
   show_cnt = j - i;
-  if (j - i > 64) 
+  if (j - i > 64)
     {
       show_cnt = 64;
       msg ("Showing first differing %zu bytes.", show_cnt);

--- a/pintos/src/tests/main.c
+++ b/pintos/src/tests/main.c
@@ -3,7 +3,7 @@
 #include "tests/main.h"
 
 int
-main (int argc UNUSED, char *argv[]) 
+main (int argc UNUSED, char *argv[])
 {
   test_name = argv[0];
 

--- a/pintos/src/tests/threads/alarm-negative.c
+++ b/pintos/src/tests/threads/alarm-negative.c
@@ -8,7 +8,7 @@
 #include "devices/timer.h"
 
 void
-test_alarm_negative (void) 
+test_alarm_negative (void)
 {
   timer_sleep (-100);
   pass ();

--- a/pintos/src/tests/threads/alarm-priority.c
+++ b/pintos/src/tests/threads/alarm-priority.c
@@ -14,17 +14,17 @@ static int64_t wake_time;
 static struct semaphore wait_sema;
 
 void
-test_alarm_priority (void) 
+test_alarm_priority (void)
 {
   int i;
-  
+
   /* This test does not work with the MLFQS. */
   ASSERT (!thread_mlfqs);
 
   wake_time = timer_ticks () + 5 * TIMER_FREQ;
   sema_init (&wait_sema, 0);
-  
-  for (i = 0; i < 10; i++) 
+
+  for (i = 0; i < 10; i++)
     {
       int priority = PRI_DEFAULT - (i + 5) % 10 - 1;
       char name[16];
@@ -39,7 +39,7 @@ test_alarm_priority (void)
 }
 
 static void
-alarm_priority_thread (void *aux UNUSED) 
+alarm_priority_thread (void *aux UNUSED)
 {
   /* Busy-wait until the current time changes. */
   int64_t start_time = timer_ticks ();

--- a/pintos/src/tests/threads/alarm-simultaneous.c
+++ b/pintos/src/tests/threads/alarm-simultaneous.c
@@ -13,13 +13,13 @@
 static void test_sleep (int thread_cnt, int iterations);
 
 void
-test_alarm_simultaneous (void) 
+test_alarm_simultaneous (void)
 {
   test_sleep (3, 5);
 }
 
 /* Information about the test. */
-struct sleep_test 
+struct sleep_test
   {
     int64_t start;              /* Current time at start of test. */
     int iterations;             /* Number of iterations per thread. */
@@ -30,7 +30,7 @@ static void sleeper (void *);
 
 /* Runs THREAD_CNT threads thread sleep ITERATIONS times each. */
 static void
-test_sleep (int thread_cnt, int iterations) 
+test_sleep (int thread_cnt, int iterations)
 {
   struct sleep_test test;
   int *output;
@@ -61,22 +61,22 @@ test_sleep (int thread_cnt, int iterations)
       snprintf (name, sizeof name, "thread %d", i);
       thread_create (name, PRI_DEFAULT, sleeper, &test);
     }
-  
+
   /* Wait long enough for all the threads to finish. */
   timer_sleep (100 + iterations * 10 + 100);
 
   /* Print completion order. */
   msg ("iteration 0, thread 0: woke up after %d ticks", output[0]);
-  for (i = 1; i < test.output_pos - output; i++) 
+  for (i = 1; i < test.output_pos - output; i++)
     msg ("iteration %d, thread %d: woke up %d ticks later",
          i / thread_cnt, i % thread_cnt, output[i] - output[i - 1]);
-  
+
   free (output);
 }
 
 /* Sleeper thread. */
 static void
-sleeper (void *test_) 
+sleeper (void *test_)
 {
   struct sleep_test *test = test_;
   int i;
@@ -84,7 +84,7 @@ sleeper (void *test_)
   /* Make sure we're at the beginning of a timer tick. */
   timer_sleep (1);
 
-  for (i = 1; i <= test->iterations; i++) 
+  for (i = 1; i <= test->iterations; i++)
     {
       int64_t sleep_until = test->start + i * 10;
       timer_sleep (sleep_until - timer_ticks ());

--- a/pintos/src/tests/threads/alarm-wait.c
+++ b/pintos/src/tests/threads/alarm-wait.c
@@ -13,19 +13,19 @@
 static void test_sleep (int thread_cnt, int iterations);
 
 void
-test_alarm_single (void) 
+test_alarm_single (void)
 {
   test_sleep (5, 1);
 }
 
 void
-test_alarm_multiple (void) 
+test_alarm_multiple (void)
 {
   test_sleep (5, 7);
 }
-
+
 /* Information about the test. */
-struct sleep_test 
+struct sleep_test
   {
     int64_t start;              /* Current time at start of test. */
     int iterations;             /* Number of iterations per thread. */
@@ -36,7 +36,7 @@ struct sleep_test
   };
 
 /* Information about an individual thread in the test. */
-struct sleep_thread 
+struct sleep_thread
   {
     struct sleep_test *test;     /* Info shared between all threads. */
     int id;                     /* Sleeper ID. */
@@ -48,7 +48,7 @@ static void sleeper (void *);
 
 /* Runs THREAD_CNT threads thread sleep ITERATIONS times each. */
 static void
-test_sleep (int thread_cnt, int iterations) 
+test_sleep (int thread_cnt, int iterations)
 {
   struct sleep_test test;
   struct sleep_thread *threads;
@@ -83,7 +83,7 @@ test_sleep (int thread_cnt, int iterations)
     {
       struct sleep_thread *t = threads + i;
       char name[16];
-      
+
       t->test = &test;
       t->id = i;
       t->duration = (i + 1) * 10;
@@ -92,7 +92,7 @@ test_sleep (int thread_cnt, int iterations)
       snprintf (name, sizeof name, "thread %d", i);
       thread_create (name, PRI_DEFAULT, sleeper, t);
     }
-  
+
   /* Wait long enough for all the threads to finish. */
   timer_sleep (100 + thread_cnt * iterations * 10 + 100);
 
@@ -102,7 +102,7 @@ test_sleep (int thread_cnt, int iterations)
 
   /* Print completion order. */
   product = 0;
-  for (op = output; op < test.output_pos; op++) 
+  for (op = output; op < test.output_pos; op++)
     {
       struct sleep_thread *t;
       int new_prod;
@@ -111,10 +111,10 @@ test_sleep (int thread_cnt, int iterations)
       t = threads + *op;
 
       new_prod = ++t->iterations * t->duration;
-        
+
       msg ("thread %d: duration=%d, iteration=%d, product=%d",
            t->id, t->duration, t->iterations, new_prod);
-      
+
       if (new_prod >= product)
         product = new_prod;
       else
@@ -127,7 +127,7 @@ test_sleep (int thread_cnt, int iterations)
     if (threads[i].iterations != iterations)
       fail ("thread %d woke up %d times instead of %d",
             i, threads[i].iterations, iterations);
-  
+
   lock_release (&test.output_lock);
   free (output);
   free (threads);
@@ -135,13 +135,13 @@ test_sleep (int thread_cnt, int iterations)
 
 /* Sleeper thread. */
 static void
-sleeper (void *t_) 
+sleeper (void *t_)
 {
   struct sleep_thread *t = t_;
   struct sleep_test *test = t->test;
   int i;
 
-  for (i = 1; i <= test->iterations; i++) 
+  for (i = 1; i <= test->iterations; i++)
     {
       int64_t sleep_until = test->start + i * t->duration;
       timer_sleep (sleep_until - timer_ticks ());

--- a/pintos/src/tests/threads/alarm-zero.c
+++ b/pintos/src/tests/threads/alarm-zero.c
@@ -8,7 +8,7 @@
 #include "devices/timer.h"
 
 void
-test_alarm_zero (void) 
+test_alarm_zero (void)
 {
   timer_sleep (0);
   pass ();

--- a/pintos/src/tests/threads/mlfqs-block.c
+++ b/pintos/src/tests/threads/mlfqs-block.c
@@ -20,17 +20,17 @@
 static void block_thread (void *lock_);
 
 void
-test_mlfqs_block (void) 
+test_mlfqs_block (void)
 {
   int64_t start_time;
   struct lock lock;
-  
+
   ASSERT (thread_mlfqs);
 
   msg ("Main thread acquiring lock.");
   lock_init (&lock);
   lock_acquire (&lock);
-  
+
   msg ("Main thread creating block thread, sleeping 25 seconds...");
   thread_create ("block", PRI_DEFAULT, block_thread, &lock);
   timer_sleep (25 * TIMER_FREQ);
@@ -47,7 +47,7 @@ test_mlfqs_block (void)
 }
 
 static void
-block_thread (void *lock_) 
+block_thread (void *lock_)
 {
   struct lock *lock = lock_;
   int64_t start_time;

--- a/pintos/src/tests/threads/mlfqs-fair.c
+++ b/pintos/src/tests/threads/mlfqs-fair.c
@@ -28,32 +28,32 @@
 static void test_mlfqs_fair (int thread_cnt, int nice_min, int nice_step);
 
 void
-test_mlfqs_fair_2 (void) 
+test_mlfqs_fair_2 (void)
 {
   test_mlfqs_fair (2, 0, 0);
 }
 
 void
-test_mlfqs_fair_20 (void) 
+test_mlfqs_fair_20 (void)
 {
   test_mlfqs_fair (20, 0, 0);
 }
 
 void
-test_mlfqs_nice_2 (void) 
+test_mlfqs_nice_2 (void)
 {
   test_mlfqs_fair (2, 0, 5);
 }
 
 void
-test_mlfqs_nice_10 (void) 
+test_mlfqs_nice_10 (void)
 {
   test_mlfqs_fair (10, 0, 1);
 }
-
+
 #define MAX_THREAD_CNT 20
 
-struct thread_info 
+struct thread_info
   {
     int64_t start_time;
     int tick_count;
@@ -81,7 +81,7 @@ test_mlfqs_fair (int thread_cnt, int nice_min, int nice_step)
   start_time = timer_ticks ();
   msg ("Starting %d threads...", thread_cnt);
   nice = nice_min;
-  for (i = 0; i < thread_cnt; i++) 
+  for (i = 0; i < thread_cnt; i++)
     {
       struct thread_info *ti = &info[i];
       char name[16];
@@ -99,13 +99,13 @@ test_mlfqs_fair (int thread_cnt, int nice_min, int nice_step)
 
   msg ("Sleeping 40 seconds to let threads run, please wait...");
   timer_sleep (40 * TIMER_FREQ);
-  
+
   for (i = 0; i < thread_cnt; i++)
     msg ("Thread %d received %d ticks.", i, info[i].tick_count);
 }
 
 static void
-load_thread (void *ti_) 
+load_thread (void *ti_)
 {
   struct thread_info *ti = ti_;
   int64_t sleep_time = 5 * TIMER_FREQ;
@@ -114,7 +114,7 @@ load_thread (void *ti_)
 
   thread_set_nice (ti->nice);
   timer_sleep (sleep_time - timer_elapsed (ti->start_time));
-  while (timer_elapsed (ti->start_time) < spin_time) 
+  while (timer_elapsed (ti->start_time) < spin_time)
     {
       int64_t cur_time = timer_ticks ();
       if (cur_time != last_time)

--- a/pintos/src/tests/threads/mlfqs-load-1.c
+++ b/pintos/src/tests/threads/mlfqs-load-1.c
@@ -15,18 +15,18 @@
 #include "devices/timer.h"
 
 void
-test_mlfqs_load_1 (void) 
+test_mlfqs_load_1 (void)
 {
   int64_t start_time;
   int elapsed;
   int load_avg;
-  
+
   ASSERT (thread_mlfqs);
 
   msg ("spinning for up to 45 seconds, please wait...");
 
   start_time = timer_ticks ();
-  for (;;) 
+  for (;;)
     {
       load_avg = thread_get_load_avg ();
       ASSERT (load_avg >= 0);

--- a/pintos/src/tests/threads/mlfqs-load-60.c
+++ b/pintos/src/tests/threads/mlfqs-load-60.c
@@ -112,15 +112,15 @@ static void load_thread (void *aux);
 #define THREAD_CNT 60
 
 void
-test_mlfqs_load_60 (void) 
+test_mlfqs_load_60 (void)
 {
   int i;
-  
+
   ASSERT (thread_mlfqs);
 
   start_time = timer_ticks ();
   msg ("Starting %d niced load threads...", THREAD_CNT);
-  for (i = 0; i < THREAD_CNT; i++) 
+  for (i = 0; i < THREAD_CNT; i++)
     {
       char name[16];
       snprintf(name, sizeof name, "load %d", i);
@@ -128,8 +128,8 @@ test_mlfqs_load_60 (void)
     }
   msg ("Starting threads took %d seconds.",
        timer_elapsed (start_time) / TIMER_FREQ);
-  
-  for (i = 0; i < 90; i++) 
+
+  for (i = 0; i < 90; i++)
     {
       int64_t sleep_until = start_time + TIMER_FREQ * (2 * i + 10);
       int load_avg;
@@ -141,7 +141,7 @@ test_mlfqs_load_60 (void)
 }
 
 static void
-load_thread (void *aux UNUSED) 
+load_thread (void *aux UNUSED)
 {
   int64_t sleep_time = 10 * TIMER_FREQ;
   int64_t spin_time = sleep_time + 60 * TIMER_FREQ;

--- a/pintos/src/tests/threads/mlfqs-load-avg.c
+++ b/pintos/src/tests/threads/mlfqs-load-avg.c
@@ -123,15 +123,15 @@ static void load_thread (void *seq_no);
 #define THREAD_CNT 60
 
 void
-test_mlfqs_load_avg (void) 
+test_mlfqs_load_avg (void)
 {
   int i;
-  
+
   ASSERT (thread_mlfqs);
 
   start_time = timer_ticks ();
   msg ("Starting %d load threads...", THREAD_CNT);
-  for (i = 0; i < THREAD_CNT; i++) 
+  for (i = 0; i < THREAD_CNT; i++)
     {
       char name[16];
       snprintf(name, sizeof name, "load %d", i);
@@ -141,7 +141,7 @@ test_mlfqs_load_avg (void)
        timer_elapsed (start_time) / TIMER_FREQ);
   thread_set_nice (-20);
 
-  for (i = 0; i < 90; i++) 
+  for (i = 0; i < 90; i++)
     {
       int64_t sleep_until = start_time + TIMER_FREQ * (2 * i + 10);
       int load_avg;
@@ -153,7 +153,7 @@ test_mlfqs_load_avg (void)
 }
 
 static void
-load_thread (void *seq_no_) 
+load_thread (void *seq_no_)
 {
   int seq_no = (int) seq_no_;
   int sleep_time = TIMER_FREQ * (10 + seq_no);

--- a/pintos/src/tests/threads/mlfqs-recent-1.c
+++ b/pintos/src/tests/threads/mlfqs-recent-1.c
@@ -93,7 +93,7 @@
    After 176 seconds, recent_cpu is 189.27, load_avg is 0.95.
    After 178 seconds, recent_cpu is 189.63, load_avg is 0.95.
    After 180 seconds, recent_cpu is 189.97, load_avg is 0.95.
-*/   
+*/
 
 #include <stdio.h>
 #include "tests/threads/tests.h"
@@ -107,14 +107,14 @@
    when timer_ticks() % TIMER_FREQ == 0. */
 
 void
-test_mlfqs_recent_1 (void) 
+test_mlfqs_recent_1 (void)
 {
   int64_t start_time;
   int last_elapsed = 0;
-  
+
   ASSERT (thread_mlfqs);
 
-  do 
+  do
     {
       msg ("Sleeping 10 seconds to allow recent_cpu to decay, please wait...");
       start_time = timer_ticks ();
@@ -124,10 +124,10 @@ test_mlfqs_recent_1 (void)
   while (thread_get_recent_cpu () > 700);
 
   start_time = timer_ticks ();
-  for (;;) 
+  for (;;)
     {
       int elapsed = timer_elapsed (start_time);
-      if (elapsed % (TIMER_FREQ * 2) == 0 && elapsed > last_elapsed) 
+      if (elapsed % (TIMER_FREQ * 2) == 0 && elapsed > last_elapsed)
         {
           int recent_cpu = thread_get_recent_cpu ();
           int load_avg = thread_get_load_avg ();
@@ -138,7 +138,7 @@ test_mlfqs_recent_1 (void)
                load_avg / 100, load_avg % 100);
           if (elapsed_seconds >= 180)
             break;
-        } 
+        }
       last_elapsed = elapsed;
     }
 }

--- a/pintos/src/tests/threads/priority-change.c
+++ b/pintos/src/tests/threads/priority-change.c
@@ -10,7 +10,7 @@
 static thread_func changing_thread;
 
 void
-test_priority_change (void) 
+test_priority_change (void)
 {
   /* This test does not work with the MLFQS. */
   ASSERT (!thread_mlfqs);
@@ -23,7 +23,7 @@ test_priority_change (void)
 }
 
 static void
-changing_thread (void *aux UNUSED) 
+changing_thread (void *aux UNUSED)
 {
   msg ("Thread 2 now lowering priority.");
   thread_set_priority (PRI_DEFAULT - 1);

--- a/pintos/src/tests/threads/priority-condvar.c
+++ b/pintos/src/tests/threads/priority-condvar.c
@@ -14,10 +14,10 @@ static struct lock lock;
 static struct condition condition;
 
 void
-test_priority_condvar (void) 
+test_priority_condvar (void)
 {
   int i;
-  
+
   /* This test does not work with the MLFQS. */
   ASSERT (!thread_mlfqs);
 
@@ -25,7 +25,7 @@ test_priority_condvar (void)
   cond_init (&condition);
 
   thread_set_priority (PRI_MIN);
-  for (i = 0; i < 10; i++) 
+  for (i = 0; i < 10; i++)
     {
       int priority = PRI_DEFAULT - (i + 7) % 10 - 1;
       char name[16];
@@ -33,7 +33,7 @@ test_priority_condvar (void)
       thread_create (name, priority, priority_condvar_thread, NULL);
     }
 
-  for (i = 0; i < 10; i++) 
+  for (i = 0; i < 10; i++)
     {
       lock_acquire (&lock);
       msg ("Signaling...");
@@ -43,7 +43,7 @@ test_priority_condvar (void)
 }
 
 static void
-priority_condvar_thread (void *aux UNUSED) 
+priority_condvar_thread (void *aux UNUSED)
 {
   msg ("Thread %s starting.", thread_name ());
   lock_acquire (&lock);

--- a/pintos/src/tests/threads/priority-donate-chain.c
+++ b/pintos/src/tests/threads/priority-donate-chain.c
@@ -1,4 +1,4 @@
-/* The main thread set its priority to PRI_MIN and creates 7 threads 
+/* The main thread set its priority to PRI_MIN and creates 7 threads
    (thread 1..7) with priorities PRI_MIN + 3, 6, 9, 12, ...
    The main thread initializes 8 locks: lock 0..7 and acquires lock 0.
 
@@ -14,15 +14,15 @@
    preempted by it.
    Thread[1] then completes acquiring lock[0], then releases lock[0],
    then releases lock[1], unblocking thread[2], etc.
-   Thread[7] finally acquires & releases lock[7] and exits, allowing 
-   thread[6], then thread[5] etc. to run and exit until finally the 
+   Thread[7] finally acquires & releases lock[7] and exits, allowing
+   thread[6], then thread[5] etc. to run and exit until finally the
    main thread exits.
 
    In addition, interloper threads are created at priority levels
-   p = PRI_MIN + 2, 5, 8, 11, ... which should not be run until the 
+   p = PRI_MIN + 2, 5, 8, 11, ... which should not be run until the
    corresponding thread with priority p + 1 has finished.
-  
-   Written by Godmar Back <gback@cs.vt.edu> */ 
+
+   Written by Godmar Back <gback@cs.vt.edu> */
 
 #include <stdio.h>
 #include "tests/threads/tests.h"
@@ -42,9 +42,9 @@ static thread_func donor_thread_func;
 static thread_func interloper_thread_func;
 
 void
-test_priority_donate_chain (void) 
+test_priority_donate_chain (void)
 {
-  int i;  
+  int i;
   struct lock locks[NESTING_DEPTH - 1];
   struct lock_pair lock_pairs[NESTING_DEPTH];
 
@@ -83,7 +83,7 @@ test_priority_donate_chain (void)
 }
 
 static void
-donor_thread_func (void *locks_) 
+donor_thread_func (void *locks_)
 {
   struct lock_pair *locks = locks_;
 
@@ -94,7 +94,7 @@ donor_thread_func (void *locks_)
   msg ("%s got lock", thread_name ());
 
   lock_release (locks->second);
-  msg ("%s should have priority %d. Actual priority: %d", 
+  msg ("%s should have priority %d. Actual priority: %d",
         thread_name (), (NESTING_DEPTH - 1) * 3,
         thread_get_priority ());
 

--- a/pintos/src/tests/threads/priority-donate-lower.c
+++ b/pintos/src/tests/threads/priority-donate-lower.c
@@ -13,7 +13,7 @@
 static thread_func acquire_thread_func;
 
 void
-test_priority_donate_lower (void) 
+test_priority_donate_lower (void)
 {
   struct lock lock;
 
@@ -40,7 +40,7 @@ test_priority_donate_lower (void)
 }
 
 static void
-acquire_thread_func (void *lock_) 
+acquire_thread_func (void *lock_)
 {
   struct lock *lock = lock_;
 

--- a/pintos/src/tests/threads/priority-donate-multiple.c
+++ b/pintos/src/tests/threads/priority-donate-multiple.c
@@ -3,7 +3,7 @@
    acquiring one of the locks and thus donate their priority to
    the main thread.  The main thread releases the locks in turn
    and relinquishes its donated priorities.
-   
+
    Based on a test originally submitted for Stanford's CS 140 in
    winter 1999 by Matt Franklin <startled@leland.stanford.edu>,
    Greg Hutchins <gmh@leland.stanford.edu>, Yu Ping Hu
@@ -19,7 +19,7 @@ static thread_func a_thread_func;
 static thread_func b_thread_func;
 
 void
-test_priority_donate_multiple (void) 
+test_priority_donate_multiple (void)
 {
   struct lock a, b;
 
@@ -55,7 +55,7 @@ test_priority_donate_multiple (void)
 }
 
 static void
-a_thread_func (void *lock_) 
+a_thread_func (void *lock_)
 {
   struct lock *lock = lock_;
 
@@ -66,7 +66,7 @@ a_thread_func (void *lock_)
 }
 
 static void
-b_thread_func (void *lock_) 
+b_thread_func (void *lock_)
 {
   struct lock *lock = lock_;
 

--- a/pintos/src/tests/threads/priority-donate-multiple2.c
+++ b/pintos/src/tests/threads/priority-donate-multiple2.c
@@ -7,8 +7,8 @@
 
    In this test, the main thread releases the locks in a different
    order compared to priority-donate-multiple.c.
-   
-   Written by Godmar Back <gback@cs.vt.edu>. 
+
+   Written by Godmar Back <gback@cs.vt.edu>.
    Based on a test originally submitted for Stanford's CS 140 in
    winter 1999 by Matt Franklin <startled@leland.stanford.edu>,
    Greg Hutchins <gmh@leland.stanford.edu>, Yu Ping Hu
@@ -25,7 +25,7 @@ static thread_func b_thread_func;
 static thread_func c_thread_func;
 
 void
-test_priority_donate_multiple2 (void) 
+test_priority_donate_multiple2 (void)
 {
   struct lock a, b;
 
@@ -62,7 +62,7 @@ test_priority_donate_multiple2 (void)
 }
 
 static void
-a_thread_func (void *lock_) 
+a_thread_func (void *lock_)
 {
   struct lock *lock = lock_;
 
@@ -73,7 +73,7 @@ a_thread_func (void *lock_)
 }
 
 static void
-b_thread_func (void *lock_) 
+b_thread_func (void *lock_)
 {
   struct lock *lock = lock_;
 
@@ -84,7 +84,7 @@ b_thread_func (void *lock_)
 }
 
 static void
-c_thread_func (void *a_ UNUSED) 
+c_thread_func (void *a_ UNUSED)
 {
   msg ("Thread c finished.");
 }

--- a/pintos/src/tests/threads/priority-donate-nest.c
+++ b/pintos/src/tests/threads/priority-donate-nest.c
@@ -3,7 +3,7 @@
    High-priority thread H then blocks on acquiring lock B.  Thus,
    thread H donates its priority to M, which in turn donates it
    to thread L.
-   
+
    Based on a test originally submitted for Stanford's CS 140 in
    winter 1999 by Matt Franklin <startled@leland.stanford.edu>,
    Greg Hutchins <gmh@leland.stanford.edu>, Yu Ping Hu
@@ -15,7 +15,7 @@
 #include "threads/synch.h"
 #include "threads/thread.h"
 
-struct locks 
+struct locks
   {
     struct lock *a;
     struct lock *b;
@@ -25,7 +25,7 @@ static thread_func medium_thread_func;
 static thread_func high_thread_func;
 
 void
-test_priority_donate_nest (void) 
+test_priority_donate_nest (void)
 {
   struct lock a, b;
   struct locks locks;
@@ -61,7 +61,7 @@ test_priority_donate_nest (void)
 }
 
 static void
-medium_thread_func (void *locks_) 
+medium_thread_func (void *locks_)
 {
   struct locks *locks = locks_;
 
@@ -83,7 +83,7 @@ medium_thread_func (void *locks_)
 }
 
 static void
-high_thread_func (void *lock_) 
+high_thread_func (void *lock_)
 {
   struct lock *lock = lock_;
 

--- a/pintos/src/tests/threads/priority-donate-one.c
+++ b/pintos/src/tests/threads/priority-donate-one.c
@@ -19,7 +19,7 @@ static thread_func acquire1_thread_func;
 static thread_func acquire2_thread_func;
 
 void
-test_priority_donate_one (void) 
+test_priority_donate_one (void)
 {
   struct lock lock;
 
@@ -43,7 +43,7 @@ test_priority_donate_one (void)
 }
 
 static void
-acquire1_thread_func (void *lock_) 
+acquire1_thread_func (void *lock_)
 {
   struct lock *lock = lock_;
 
@@ -54,7 +54,7 @@ acquire1_thread_func (void *lock_)
 }
 
 static void
-acquire2_thread_func (void *lock_) 
+acquire2_thread_func (void *lock_)
 {
   struct lock *lock = lock_;
 

--- a/pintos/src/tests/threads/priority-donate-sema.c
+++ b/pintos/src/tests/threads/priority-donate-sema.c
@@ -16,7 +16,7 @@
 #include "threads/synch.h"
 #include "threads/thread.h"
 
-struct lock_and_sema 
+struct lock_and_sema
   {
     struct lock lock;
     struct semaphore sema;
@@ -27,7 +27,7 @@ static thread_func m_thread_func;
 static thread_func h_thread_func;
 
 void
-test_priority_donate_sema (void) 
+test_priority_donate_sema (void)
 {
   struct lock_and_sema ls;
 
@@ -47,7 +47,7 @@ test_priority_donate_sema (void)
 }
 
 static void
-l_thread_func (void *ls_) 
+l_thread_func (void *ls_)
 {
   struct lock_and_sema *ls = ls_;
 
@@ -60,7 +60,7 @@ l_thread_func (void *ls_)
 }
 
 static void
-m_thread_func (void *ls_) 
+m_thread_func (void *ls_)
 {
   struct lock_and_sema *ls = ls_;
 
@@ -69,7 +69,7 @@ m_thread_func (void *ls_)
 }
 
 static void
-h_thread_func (void *ls_) 
+h_thread_func (void *ls_)
 {
   struct lock_and_sema *ls = ls_;
 

--- a/pintos/src/tests/threads/priority-fifo.c
+++ b/pintos/src/tests/threads/priority-fifo.c
@@ -15,7 +15,7 @@
 #include "threads/synch.h"
 #include "threads/thread.h"
 
-struct simple_thread_data 
+struct simple_thread_data
   {
     int id;                     /* Sleeper ID. */
     int iterations;             /* Iterations so far. */
@@ -29,7 +29,7 @@ struct simple_thread_data
 static thread_func simple_thread_func;
 
 void
-test_priority_fifo (void) 
+test_priority_fifo (void)
 {
   struct simple_thread_data data[THREAD_CNT];
   struct lock lock;
@@ -51,7 +51,7 @@ test_priority_fifo (void)
   lock_init (&lock);
 
   thread_set_priority (PRI_DEFAULT + 2);
-  for (i = 0; i < THREAD_CNT; i++) 
+  for (i = 0; i < THREAD_CNT; i++)
     {
       char name[16];
       struct simple_thread_data *d = data + i;
@@ -68,7 +68,7 @@ test_priority_fifo (void)
   ASSERT (lock.holder == NULL);
 
   cnt = 0;
-  for (; output < op; output++) 
+  for (; output < op; output++)
     {
       struct simple_thread_data *d;
 
@@ -83,13 +83,13 @@ test_priority_fifo (void)
     }
 }
 
-static void 
-simple_thread_func (void *data_) 
+static void
+simple_thread_func (void *data_)
 {
   struct simple_thread_data *data = data_;
   int i;
-  
-  for (i = 0; i < ITER_CNT; i++) 
+
+  for (i = 0; i < ITER_CNT; i++)
     {
       lock_acquire (data->lock);
       *(*data->op)++ = data->id;

--- a/pintos/src/tests/threads/priority-preempt.c
+++ b/pintos/src/tests/threads/priority-preempt.c
@@ -15,7 +15,7 @@
 static thread_func simple_thread_func;
 
 void
-test_priority_preempt (void) 
+test_priority_preempt (void)
 {
   /* This test does not work with the MLFQS. */
   ASSERT (!thread_mlfqs);
@@ -27,12 +27,12 @@ test_priority_preempt (void)
   msg ("The high-priority thread should have already completed.");
 }
 
-static void 
-simple_thread_func (void *aux UNUSED) 
+static void
+simple_thread_func (void *aux UNUSED)
 {
   int i;
-  
-  for (i = 0; i < 5; i++) 
+
+  for (i = 0; i < 5; i++)
     {
       msg ("Thread %s iteration %d", thread_name (), i);
       thread_yield ();

--- a/pintos/src/tests/threads/priority-sema.c
+++ b/pintos/src/tests/threads/priority-sema.c
@@ -13,16 +13,16 @@ static thread_func priority_sema_thread;
 static struct semaphore sema;
 
 void
-test_priority_sema (void) 
+test_priority_sema (void)
 {
   int i;
-  
+
   /* This test does not work with the MLFQS. */
   ASSERT (!thread_mlfqs);
 
   sema_init (&sema, 0);
   thread_set_priority (PRI_MIN);
-  for (i = 0; i < 10; i++) 
+  for (i = 0; i < 10; i++)
     {
       int priority = PRI_DEFAULT - (i + 3) % 10 - 1;
       char name[16];
@@ -30,15 +30,15 @@ test_priority_sema (void)
       thread_create (name, priority, priority_sema_thread, NULL);
     }
 
-  for (i = 0; i < 10; i++) 
+  for (i = 0; i < 10; i++)
     {
       sema_up (&sema);
-      msg ("Back in main thread."); 
+      msg ("Back in main thread.");
     }
 }
 
 static void
-priority_sema_thread (void *aux UNUSED) 
+priority_sema_thread (void *aux UNUSED)
 {
   sema_down (&sema);
   msg ("Thread %s woke up.", thread_name ());

--- a/pintos/src/tests/threads/tests.c
+++ b/pintos/src/tests/threads/tests.c
@@ -3,13 +3,13 @@
 #include <string.h>
 #include <stdio.h>
 
-struct test 
+struct test
   {
     const char *name;
     test_func *function;
   };
 
-static const struct test tests[] = 
+static const struct test tests[] =
   {
     {"alarm-single", test_alarm_single},
     {"alarm-multiple", test_alarm_multiple},
@@ -44,7 +44,7 @@ static const char *test_name;
 
 /* Runs the test named NAME. */
 void
-run_test (const char *name) 
+run_test (const char *name)
 {
   const struct test *t;
 
@@ -64,10 +64,10 @@ run_test (const char *name)
    prefixing the output by the name of the test
    and following it with a new-line character. */
 void
-msg (const char *format, ...) 
+msg (const char *format, ...)
 {
   va_list args;
-  
+
   printf ("(%s) ", test_name);
   va_start (args, format);
   vprintf (format, args);
@@ -80,10 +80,10 @@ msg (const char *format, ...)
    and following it with a new-line character,
    and then panics the kernel. */
 void
-fail (const char *format, ...) 
+fail (const char *format, ...)
 {
   va_list args;
-  
+
   printf ("(%s) FAIL: ", test_name);
   va_start (args, format);
   vprintf (format, args);
@@ -95,7 +95,7 @@ fail (const char *format, ...)
 
 /* Prints a message indicating the current test passed. */
 void
-pass (void) 
+pass (void)
 {
   printf ("(%s) PASS\n", test_name);
 }

--- a/pintos/src/tests/userprog/args.c
+++ b/pintos/src/tests/userprog/args.c
@@ -6,7 +6,7 @@
 #include "tests/lib.h"
 
 int
-main (int argc, char *argv[]) 
+main (int argc, char *argv[])
 {
   int i;
 

--- a/pintos/src/tests/userprog/bad-jump.c
+++ b/pintos/src/tests/userprog/bad-jump.c
@@ -7,10 +7,10 @@
 typedef int (* volatile functionptr)(void);
 
 void
-test_main (void) 
+test_main (void)
 {
   functionptr fp = NULL;
-  msg ("Congratulations - you have successfully called NULL: %d", 
+  msg ("Congratulations - you have successfully called NULL: %d",
         fp());
   fail ("should have exited with -1");
 }

--- a/pintos/src/tests/userprog/bad-jump2.c
+++ b/pintos/src/tests/userprog/bad-jump2.c
@@ -1,13 +1,13 @@
-/* This program attempts to execute code at a kernel virtual address. 
+/* This program attempts to execute code at a kernel virtual address.
    This should terminate the process with a -1 exit code. */
 
 #include "tests/lib.h"
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
-  msg ("Congratulations - you have successfully called kernel code: %d", 
+  msg ("Congratulations - you have successfully called kernel code: %d",
         ((int (*)(void))0xC0000000)());
   fail ("should have exited with -1");
 }

--- a/pintos/src/tests/userprog/bad-read.c
+++ b/pintos/src/tests/userprog/bad-read.c
@@ -5,9 +5,9 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
-  msg ("Congratulations - you have successfully dereferenced NULL: %d", 
+  msg ("Congratulations - you have successfully dereferenced NULL: %d",
         *(volatile int *) NULL);
   fail ("should have exited with -1");
 }

--- a/pintos/src/tests/userprog/bad-read2.c
+++ b/pintos/src/tests/userprog/bad-read2.c
@@ -1,13 +1,13 @@
-/* This program attempts to read kernel memory. 
+/* This program attempts to read kernel memory.
    This should terminate the process with a -1 exit code. */
 
 #include "tests/lib.h"
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
-  msg ("Congratulations - you have successfully read kernel memory: %d", 
+  msg ("Congratulations - you have successfully read kernel memory: %d",
         *(int *)0xC0000000);
   fail ("should have exited with -1");
 }

--- a/pintos/src/tests/userprog/bad-write.c
+++ b/pintos/src/tests/userprog/bad-write.c
@@ -5,7 +5,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   *(volatile int *)NULL = 42;
   fail ("should have exited with -1");

--- a/pintos/src/tests/userprog/bad-write2.c
+++ b/pintos/src/tests/userprog/bad-write2.c
@@ -1,11 +1,11 @@
-/* This program attempts to write to kernel memory. 
+/* This program attempts to write to kernel memory.
    This should terminate the process with a -1 exit code. */
 
 #include "tests/lib.h"
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   *(int *)0xC0000000 = 42;
   fail ("should have exited with -1");

--- a/pintos/src/tests/userprog/boundary.c
+++ b/pintos/src/tests/userprog/boundary.c
@@ -12,7 +12,7 @@ static char dst[8192];
 /* Returns the beginning of a page.  There are at least 2048
    modifiable bytes on either side of the pointer returned. */
 void *
-get_boundary_area (void) 
+get_boundary_area (void)
 {
   char *p = (char *) ROUND_UP ((uintptr_t) dst, 4096);
   if (p - dst < 2048)
@@ -23,7 +23,7 @@ get_boundary_area (void)
 /* Returns a copy of SRC split across the boundary between two
    pages. */
 char *
-copy_string_across_boundary (const char *src) 
+copy_string_across_boundary (const char *src)
 {
   char *p = get_boundary_area ();
   p -= strlen (src) < 4096 ? strlen (src) / 2 : 4096;

--- a/pintos/src/tests/userprog/child-bad.c
+++ b/pintos/src/tests/userprog/child-bad.c
@@ -7,7 +7,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   asm volatile ("movl $0x20101234, %esp; int $0x30");
   fail ("should have exited with -1");

--- a/pintos/src/tests/userprog/child-close.c
+++ b/pintos/src/tests/userprog/child-close.c
@@ -16,7 +16,7 @@
 const char *test_name = "child-close";
 
 int
-main (int argc UNUSED, char *argv[]) 
+main (int argc UNUSED, char *argv[])
 {
   msg ("begin");
   if (!isdigit (*argv[1]))

--- a/pintos/src/tests/userprog/child-rox.c
+++ b/pintos/src/tests/userprog/child-rox.c
@@ -13,7 +13,7 @@
 const char *test_name = "child-rox";
 
 static void
-try_write (void) 
+try_write (void)
 {
   int handle;
   char buffer[19];
@@ -24,23 +24,23 @@ try_write (void)
 
   CHECK (write (handle, buffer, sizeof buffer) == 0,
          "try to write \"child-rox\"");
-  
+
   close (handle);
 }
 
 int
-main (int argc UNUSED, char *argv[]) 
+main (int argc UNUSED, char *argv[])
 {
   msg ("begin");
   try_write ();
 
   if (!isdigit (*argv[1]))
     fail ("bad command-line arguments");
-  if (atoi (argv[1]) > 1) 
+  if (atoi (argv[1]) > 1)
     {
       char cmd[128];
       int child;
-      
+
       snprintf (cmd, sizeof cmd, "child-rox %d", atoi (argv[1]) - 1);
       CHECK ((child = exec (cmd)) != -1, "exec \"%s\"", cmd);
       quiet = true;

--- a/pintos/src/tests/userprog/child-simple.c
+++ b/pintos/src/tests/userprog/child-simple.c
@@ -8,7 +8,7 @@
 const char *test_name = "child-simple";
 
 int
-main (void) 
+main (void)
 {
   msg ("run");
   return 81;

--- a/pintos/src/tests/userprog/close-bad-fd.c
+++ b/pintos/src/tests/userprog/close-bad-fd.c
@@ -5,7 +5,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   close (0x20101234);
 }

--- a/pintos/src/tests/userprog/close-normal.c
+++ b/pintos/src/tests/userprog/close-normal.c
@@ -5,7 +5,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   int handle;
   CHECK ((handle = open ("sample.txt")) > 1, "open \"sample.txt\"");

--- a/pintos/src/tests/userprog/close-stdin.c
+++ b/pintos/src/tests/userprog/close-stdin.c
@@ -5,7 +5,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   close (0);
 }

--- a/pintos/src/tests/userprog/close-stdout.c
+++ b/pintos/src/tests/userprog/close-stdout.c
@@ -5,7 +5,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   close (1);
 }

--- a/pintos/src/tests/userprog/close-twice.c
+++ b/pintos/src/tests/userprog/close-twice.c
@@ -7,7 +7,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   int handle;
   CHECK ((handle = open ("sample.txt")) > 1, "open \"sample.txt\"");

--- a/pintos/src/tests/userprog/create-bad-ptr.c
+++ b/pintos/src/tests/userprog/create-bad-ptr.c
@@ -6,7 +6,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   msg ("create(0x20101234): %d", create ((char *) 0x20101234, 0));
 }

--- a/pintos/src/tests/userprog/create-bound.c
+++ b/pintos/src/tests/userprog/create-bound.c
@@ -7,7 +7,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   msg ("create(\"quux.dat\"): %d",
        create (copy_string_across_boundary ("quux.dat"), 0));

--- a/pintos/src/tests/userprog/create-empty.c
+++ b/pintos/src/tests/userprog/create-empty.c
@@ -4,7 +4,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   msg ("create(\"\"): %d", create ("", 0));
 }

--- a/pintos/src/tests/userprog/create-exists.c
+++ b/pintos/src/tests/userprog/create-exists.c
@@ -6,7 +6,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   CHECK (create ("quux.dat", 0), "create quux.dat");
   CHECK (create ("warble.dat", 0), "create warble.dat");

--- a/pintos/src/tests/userprog/create-long.c
+++ b/pintos/src/tests/userprog/create-long.c
@@ -7,11 +7,11 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   static char name[512];
   memset (name, 'x', sizeof name);
   name[sizeof name - 1] = '\0';
-  
+
   msg ("create(\"x...\"): %d", create (name, 0));
 }

--- a/pintos/src/tests/userprog/create-normal.c
+++ b/pintos/src/tests/userprog/create-normal.c
@@ -4,7 +4,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   CHECK (create ("quux.dat", 0), "create quux.dat");
 }

--- a/pintos/src/tests/userprog/create-null.c
+++ b/pintos/src/tests/userprog/create-null.c
@@ -5,7 +5,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   msg ("create(NULL): %d", create (NULL, 0));
 }

--- a/pintos/src/tests/userprog/exec-arg.c
+++ b/pintos/src/tests/userprog/exec-arg.c
@@ -4,7 +4,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   wait (exec ("child-args childarg"));
 }

--- a/pintos/src/tests/userprog/exec-bad-ptr.c
+++ b/pintos/src/tests/userprog/exec-bad-ptr.c
@@ -5,7 +5,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   exec ((char *) 0x20101234);
 }

--- a/pintos/src/tests/userprog/exec-missing.c
+++ b/pintos/src/tests/userprog/exec-missing.c
@@ -6,7 +6,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   msg ("exec(\"no-such-file\"): %d", exec ("no-such-file"));
 }

--- a/pintos/src/tests/userprog/exec-multiple.c
+++ b/pintos/src/tests/userprog/exec-multiple.c
@@ -5,7 +5,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   wait (exec ("child-simple"));
   wait (exec ("child-simple"));

--- a/pintos/src/tests/userprog/exec-once.c
+++ b/pintos/src/tests/userprog/exec-once.c
@@ -5,7 +5,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   wait (exec ("child-simple"));
 }

--- a/pintos/src/tests/userprog/exit.c
+++ b/pintos/src/tests/userprog/exit.c
@@ -4,7 +4,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   exit (57);
   fail ("should have called exit(57)");

--- a/pintos/src/tests/userprog/halt.c
+++ b/pintos/src/tests/userprog/halt.c
@@ -4,7 +4,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   halt ();
   fail ("should have halted");

--- a/pintos/src/tests/userprog/iloveos.c
+++ b/pintos/src/tests/userprog/iloveos.c
@@ -5,7 +5,7 @@
 #include <string.h>
 
 void
-test_main (void) 
+test_main (void)
 {
   char *msg = "I love CS162\n";
   write(1, msg, strlen(msg));

--- a/pintos/src/tests/userprog/multi-child-fd.c
+++ b/pintos/src/tests/userprog/multi-child-fd.c
@@ -10,7 +10,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   char child_cmd[128];
   int handle;
@@ -18,7 +18,7 @@ test_main (void)
   CHECK ((handle = open ("sample.txt")) > 1, "open \"sample.txt\"");
 
   snprintf (child_cmd, sizeof child_cmd, "child-close %d", handle);
-  
+
   msg ("wait(exec()) = %d", wait (exec (child_cmd)));
 
   check_file_handle (handle, "sample.txt", sample, sizeof sample - 1);

--- a/pintos/src/tests/userprog/multi-recurse.c
+++ b/pintos/src/tests/userprog/multi-recurse.c
@@ -10,17 +10,17 @@
 const char *test_name = "multi-recurse";
 
 int
-main (int argc UNUSED, char *argv[]) 
+main (int argc UNUSED, char *argv[])
 {
   int n = atoi (argv[1]);
 
   msg ("begin %d", n);
-  if (n != 0) 
+  if (n != 0)
     {
       char child_cmd[128];
       pid_t child_pid;
       int code;
-      
+
       snprintf (child_cmd, sizeof child_cmd, "multi-recurse %d", n - 1);
       CHECK ((child_pid = exec (child_cmd)) != -1, "exec(\"%s\")", child_cmd);
 
@@ -28,7 +28,7 @@ main (int argc UNUSED, char *argv[])
       if (code != n - 1)
         fail ("wait(exec(\"%s\")) returned %d", child_cmd, code);
     }
-  
+
   msg ("end %d", n);
   return n;
 }

--- a/pintos/src/tests/userprog/open-bad-ptr.c
+++ b/pintos/src/tests/userprog/open-bad-ptr.c
@@ -6,7 +6,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   msg ("open(0x20101234): %d", open ((char *) 0x20101234));
   fail ("should have called exit(-1)");

--- a/pintos/src/tests/userprog/open-boundary.c
+++ b/pintos/src/tests/userprog/open-boundary.c
@@ -7,7 +7,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   CHECK (open (copy_string_across_boundary ("sample.txt")) > 1,
          "open \"sample.txt\"");

--- a/pintos/src/tests/userprog/open-empty.c
+++ b/pintos/src/tests/userprog/open-empty.c
@@ -5,7 +5,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   int handle = open ("");
   if (handle != -1)

--- a/pintos/src/tests/userprog/open-missing.c
+++ b/pintos/src/tests/userprog/open-missing.c
@@ -5,7 +5,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   int handle = open ("no-such-file");
   if (handle != -1)

--- a/pintos/src/tests/userprog/open-normal.c
+++ b/pintos/src/tests/userprog/open-normal.c
@@ -5,7 +5,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   int handle = open ("sample.txt");
   if (handle < 2)

--- a/pintos/src/tests/userprog/open-null.c
+++ b/pintos/src/tests/userprog/open-null.c
@@ -6,7 +6,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   open (NULL);
 }

--- a/pintos/src/tests/userprog/open-twice.c
+++ b/pintos/src/tests/userprog/open-twice.c
@@ -7,10 +7,10 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   int h1 = open ("sample.txt");
-  int h2 = open ("sample.txt");  
+  int h2 = open ("sample.txt");
 
   CHECK ((h1 = open ("sample.txt")) > 1, "open \"sample.txt\" once");
   CHECK ((h2 = open ("sample.txt")) > 1, "open \"sample.txt\" again");

--- a/pintos/src/tests/userprog/read-bad-fd.c
+++ b/pintos/src/tests/userprog/read-bad-fd.c
@@ -8,7 +8,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   char buf;
   read (0x20101234, &buf, 1);

--- a/pintos/src/tests/userprog/read-bad-ptr.c
+++ b/pintos/src/tests/userprog/read-bad-ptr.c
@@ -6,7 +6,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   int handle;
   CHECK ((handle = open ("sample.txt")) > 1, "open \"sample.txt\"");

--- a/pintos/src/tests/userprog/read-boundary.c
+++ b/pintos/src/tests/userprog/read-boundary.c
@@ -9,7 +9,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   int handle;
   int byte_cnt;
@@ -21,7 +21,7 @@ test_main (void)
   byte_cnt = read (handle, buffer, sizeof sample - 1);
   if (byte_cnt != sizeof sample - 1)
     fail ("read() returned %d instead of %zu", byte_cnt, sizeof sample - 1);
-  else if (strcmp (sample, buffer)) 
+  else if (strcmp (sample, buffer))
     {
       msg ("expected text:\n%s", sample);
       msg ("text actually read:\n%s", buffer);

--- a/pintos/src/tests/userprog/read-normal.c
+++ b/pintos/src/tests/userprog/read-normal.c
@@ -5,7 +5,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   check_file ("sample.txt", sample, sizeof sample - 1);
 }

--- a/pintos/src/tests/userprog/read-stdout.c
+++ b/pintos/src/tests/userprog/read-stdout.c
@@ -1,4 +1,4 @@
-/* Try reading from fd 1 (stdout), 
+/* Try reading from fd 1 (stdout),
    which may just fail or terminate the process with -1 exit
    code. */
 
@@ -7,7 +7,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   char buf;
   read (STDOUT_FILENO, &buf, 1);

--- a/pintos/src/tests/userprog/read-zero.c
+++ b/pintos/src/tests/userprog/read-zero.c
@@ -6,7 +6,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   int handle, byte_cnt;
   char buf;

--- a/pintos/src/tests/userprog/rox-simple.c
+++ b/pintos/src/tests/userprog/rox-simple.c
@@ -6,11 +6,11 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   int handle;
   char buffer[16];
-  
+
   CHECK ((handle = open ("rox-simple")) > 1, "open \"rox-simple\"");
   CHECK (read (handle, buffer, sizeof buffer) == (int) sizeof buffer,
          "read \"rox-simple\"");

--- a/pintos/src/tests/userprog/sc-bad-arg.c
+++ b/pintos/src/tests/userprog/sc-bad-arg.c
@@ -9,7 +9,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   asm volatile ("movl $0xbffffffc, %%esp; movl %0, (%%esp); int $0x30"
                 : : "i" (SYS_EXIT));

--- a/pintos/src/tests/userprog/sc-bad-sp.c
+++ b/pintos/src/tests/userprog/sc-bad-sp.c
@@ -1,6 +1,6 @@
 /* Invokes a system call with the stack pointer (%esp) set to a
    bad address.  The process must be terminated with -1 exit
-   code. 
+   code.
 
    For Project 3: The bad address lies approximately 64MB below
    the code segment, so there is no ambiguity that this attempt
@@ -13,7 +13,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   asm volatile ("movl $.-(64*1024*1024), %esp; int $0x30");
   fail ("should have called exit(-1)");

--- a/pintos/src/tests/userprog/sc-boundary-2.c
+++ b/pintos/src/tests/userprog/sc-boundary-2.c
@@ -8,7 +8,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   /* Make one byte of a syscall argument hang over into a second
      page. */

--- a/pintos/src/tests/userprog/sc-boundary.c
+++ b/pintos/src/tests/userprog/sc-boundary.c
@@ -7,7 +7,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   /* Put a syscall number at the end of one page
      and its argument at the beginning of another. */

--- a/pintos/src/tests/userprog/wait-bad-pid.c
+++ b/pintos/src/tests/userprog/wait-bad-pid.c
@@ -5,7 +5,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   wait ((pid_t) 0x0c020301);
 }

--- a/pintos/src/tests/userprog/wait-killed.c
+++ b/pintos/src/tests/userprog/wait-killed.c
@@ -5,7 +5,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   msg ("wait(exec()) = %d", wait (exec ("child-bad")));
 }

--- a/pintos/src/tests/userprog/wait-simple.c
+++ b/pintos/src/tests/userprog/wait-simple.c
@@ -5,7 +5,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   msg ("wait(exec()) = %d", wait (exec ("child-simple")));
 }

--- a/pintos/src/tests/userprog/wait-twice.c
+++ b/pintos/src/tests/userprog/wait-twice.c
@@ -7,7 +7,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   pid_t child = exec ("child-simple");
   msg ("wait(exec()) = %d", wait (child));

--- a/pintos/src/tests/userprog/write-bad-fd.c
+++ b/pintos/src/tests/userprog/write-bad-fd.c
@@ -7,7 +7,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   char buf = 123;
   write (0x01012342, &buf, 1);

--- a/pintos/src/tests/userprog/write-bad-ptr.c
+++ b/pintos/src/tests/userprog/write-bad-ptr.c
@@ -6,7 +6,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   int handle;
   CHECK ((handle = open ("sample.txt")) > 1, "open \"sample.txt\"");

--- a/pintos/src/tests/userprog/write-boundary.c
+++ b/pintos/src/tests/userprog/write-boundary.c
@@ -9,7 +9,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   int handle;
   int byte_cnt;

--- a/pintos/src/tests/userprog/write-normal.c
+++ b/pintos/src/tests/userprog/write-normal.c
@@ -6,7 +6,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   int handle, byte_cnt;
 

--- a/pintos/src/tests/userprog/write-stdin.c
+++ b/pintos/src/tests/userprog/write-stdin.c
@@ -1,4 +1,4 @@
-/* Try writing to fd 0 (stdin), 
+/* Try writing to fd 0 (stdin),
    which may just fail or terminate the process with -1 exit
    code. */
 
@@ -7,7 +7,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   char buf = 123;
   write (0, &buf, 1);

--- a/pintos/src/tests/userprog/write-zero.c
+++ b/pintos/src/tests/userprog/write-zero.c
@@ -6,7 +6,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   int handle, byte_cnt;
   char buf;

--- a/pintos/src/tests/vm/child-qsort-mm.c
+++ b/pintos/src/tests/vm/child-qsort-mm.c
@@ -10,7 +10,7 @@
 const char *test_name = "child-qsort-mm";
 
 int
-main (int argc UNUSED, char *argv[]) 
+main (int argc UNUSED, char *argv[])
 {
   int handle;
   unsigned char *p = (unsigned char *) 0x10000000;
@@ -20,6 +20,6 @@ main (int argc UNUSED, char *argv[])
   CHECK ((handle = open (argv[1])) > 1, "open \"%s\"", argv[1]);
   CHECK (mmap (handle, p) != MAP_FAILED, "mmap \"%s\"", argv[1]);
   qsort_bytes (p, 1024 * 128);
-  
+
   return 80;
 }

--- a/pintos/src/tests/vm/child-qsort.c
+++ b/pintos/src/tests/vm/child-qsort.c
@@ -12,7 +12,7 @@
 const char *test_name = "child-qsort";
 
 int
-main (int argc UNUSED, char *argv[]) 
+main (int argc UNUSED, char *argv[])
 {
   int handle;
   unsigned char buf[128 * 1024];
@@ -27,6 +27,6 @@ main (int argc UNUSED, char *argv[])
   seek (handle, 0);
   write (handle, buf, size);
   close (handle);
-  
+
   return 72;
 }

--- a/pintos/src/tests/vm/child-sort.c
+++ b/pintos/src/tests/vm/child-sort.c
@@ -13,7 +13,7 @@ unsigned char buf[128 * 1024];
 size_t histogram[256];
 
 int
-main (int argc UNUSED, char *argv[]) 
+main (int argc UNUSED, char *argv[])
 {
   int handle;
   unsigned char *p;
@@ -28,7 +28,7 @@ main (int argc UNUSED, char *argv[])
   for (i = 0; i < size; i++)
     histogram[buf[i]]++;
   p = buf;
-  for (i = 0; i < sizeof histogram / sizeof *histogram; i++) 
+  for (i = 0; i < sizeof histogram / sizeof *histogram; i++)
     {
       size_t j = histogram[i];
       while (j-- > 0)
@@ -37,6 +37,6 @@ main (int argc UNUSED, char *argv[])
   seek (handle, 0);
   write (handle, buf, size);
   close (handle);
-  
+
   return 123;
 }

--- a/pintos/src/tests/vm/mmap-bad-fd.c
+++ b/pintos/src/tests/vm/mmap-bad-fd.c
@@ -7,7 +7,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   CHECK (mmap (0x5678, (void *) 0x10000000) == MAP_FAILED,
          "try to mmap invalid fd");

--- a/pintos/src/tests/vm/mmap-clean.c
+++ b/pintos/src/tests/vm/mmap-clean.c
@@ -41,12 +41,12 @@ test_main (void)
   /* Verify that file overwrite worked. */
   if (memcmp (buffer, overwrite, strlen (overwrite))
       || memcmp (buffer + strlen (overwrite), sample + strlen (overwrite),
-                 strlen (sample) - strlen (overwrite))) 
+                 strlen (sample) - strlen (overwrite)))
     {
       if (!memcmp (buffer, sample, strlen (sample)))
         fail ("munmap wrote back clean page");
       else
-        fail ("read surprising data from file"); 
+        fail ("read surprising data from file");
     }
   else
     msg ("file change was retained after munmap");

--- a/pintos/src/tests/vm/mmap-misalign.c
+++ b/pintos/src/tests/vm/mmap-misalign.c
@@ -5,10 +5,10 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   int handle;
-  
+
   CHECK ((handle = open ("sample.txt")) > 1, "open \"sample.txt\"");
   CHECK (mmap (handle, (void *) 0x10001234) == MAP_FAILED,
          "try to mmap at misaligned address");

--- a/pintos/src/tests/vm/mmap-null.c
+++ b/pintos/src/tests/vm/mmap-null.c
@@ -5,10 +5,10 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   int handle;
-  
+
   CHECK ((handle = open ("sample.txt")) > 1, "open \"sample.txt\"");
   CHECK (mmap (handle, NULL) == MAP_FAILED, "try to mmap at address 0");
 }

--- a/pintos/src/tests/vm/mmap-over-code.c
+++ b/pintos/src/tests/vm/mmap-over-code.c
@@ -7,11 +7,11 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   uintptr_t test_main_page = ROUND_DOWN ((uintptr_t) test_main, 4096);
   int handle;
-  
+
   CHECK ((handle = open ("sample.txt")) > 1, "open \"sample.txt\"");
   CHECK (mmap (handle, (void *) test_main_page) == MAP_FAILED,
          "try to mmap over code segment");

--- a/pintos/src/tests/vm/mmap-over-data.c
+++ b/pintos/src/tests/vm/mmap-over-data.c
@@ -9,11 +9,11 @@
 static char x;
 
 void
-test_main (void) 
+test_main (void)
 {
   uintptr_t x_page = ROUND_DOWN ((uintptr_t) &x, 4096);
   int handle;
-  
+
   CHECK ((handle = open ("sample.txt")) > 1, "open \"sample.txt\"");
   CHECK (mmap (handle, (void *) x_page) == MAP_FAILED,
          "try to mmap over data segment");

--- a/pintos/src/tests/vm/mmap-over-stk.c
+++ b/pintos/src/tests/vm/mmap-over-stk.c
@@ -7,11 +7,11 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   int handle;
   uintptr_t handle_page = ROUND_DOWN ((uintptr_t) &handle, 4096);
-  
+
   CHECK ((handle = open ("sample.txt")) > 1, "open \"sample.txt\"");
   CHECK (mmap (handle, (void *) handle_page) == MAP_FAILED,
          "try to mmap over stack segment");

--- a/pintos/src/tests/vm/mmap-shuffle.c
+++ b/pintos/src/tests/vm/mmap-shuffle.c
@@ -28,7 +28,7 @@ test_main (void)
   for (i = 0; i < SIZE; i++)
     buf[i] = i * 257;
   msg ("init: cksum=%lu", cksum (buf, SIZE));
-    
+
   /* Shuffle repeatedly. */
   for (i = 0; i < 10; i++)
     {

--- a/pintos/src/tests/vm/mmap-twice.c
+++ b/pintos/src/tests/vm/mmap-twice.c
@@ -14,7 +14,7 @@ test_main (void)
   size_t i;
   int handle[2];
 
-  for (i = 0; i < 2; i++) 
+  for (i = 0; i < 2; i++)
     {
       CHECK ((handle[i] = open ("sample.txt")) > 1,
              "open \"sample.txt\" #%zu", i);

--- a/pintos/src/tests/vm/mmap-zero.c
+++ b/pintos/src/tests/vm/mmap-zero.c
@@ -8,7 +8,7 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   char *data = (char *) 0x7f000000;
   int handle;

--- a/pintos/src/tests/vm/page-merge-mm.c
+++ b/pintos/src/tests/vm/page-merge-mm.c
@@ -2,7 +2,7 @@
 #include "tests/vm/parallel-merge.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   parallel_merge ("child-qsort-mm", 80);
 }

--- a/pintos/src/tests/vm/page-merge-par.c
+++ b/pintos/src/tests/vm/page-merge-par.c
@@ -2,7 +2,7 @@
 #include "tests/vm/parallel-merge.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   parallel_merge ("child-sort", 123);
 }

--- a/pintos/src/tests/vm/page-merge-seq.c
+++ b/pintos/src/tests/vm/page-merge-seq.c
@@ -21,7 +21,7 @@ size_t histogram[256];
 /* Initialize buf1 with random data,
    then count the number of instances of each value within it. */
 static void
-init (void) 
+init (void)
 {
   struct arc4 arc4;
   size_t i;
@@ -41,7 +41,7 @@ sort_chunks (void)
   size_t i;
 
   create ("buffer", CHUNK_SIZE);
-  for (i = 0; i < CHUNK_CNT; i++) 
+  for (i = 0; i < CHUNK_CNT; i++)
     {
       pid_t child;
       int handle;
@@ -70,7 +70,7 @@ sort_chunks (void)
 
 /* Merge the sorted chunks in buf1 into a fully sorted buf2. */
 static void
-merge (void) 
+merge (void)
 {
   unsigned char *mp[CHUNK_CNT];
   size_t mp_left;
@@ -86,7 +86,7 @@ merge (void)
 
   /* Merge. */
   op = buf2;
-  while (mp_left > 0) 
+  while (mp_left > 0)
     {
       /* Find smallest value. */
       size_t min = 0;
@@ -98,14 +98,14 @@ merge (void)
       *op++ = *mp[min];
 
       /* Advance merge pointer.
-         Delete this chunk from the set if it's emptied. */ 
+         Delete this chunk from the set if it's emptied. */
       if ((++mp[min] - buf1) % CHUNK_SIZE == 0)
-        mp[min] = mp[--mp_left]; 
+        mp[min] = mp[--mp_left];
     }
 }
 
 static void
-verify (void) 
+verify (void)
 {
   size_t buf_idx;
   size_t hist_idx;
@@ -116,12 +116,12 @@ verify (void)
   for (hist_idx = 0; hist_idx < sizeof histogram / sizeof *histogram;
        hist_idx++)
     {
-      while (histogram[hist_idx]-- > 0) 
+      while (histogram[hist_idx]-- > 0)
         {
           if (buf2[buf_idx] != hist_idx)
             fail ("bad value %d in byte %zu", buf2[buf_idx], buf_idx);
           buf_idx++;
-        } 
+        }
     }
 
   msg ("success, buf_idx=%'zu", buf_idx);

--- a/pintos/src/tests/vm/page-merge-stk.c
+++ b/pintos/src/tests/vm/page-merge-stk.c
@@ -2,7 +2,7 @@
 #include "tests/vm/parallel-merge.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   parallel_merge ("child-qsort", 72);
 }

--- a/pintos/src/tests/vm/page-parallel.c
+++ b/pintos/src/tests/vm/page-parallel.c
@@ -12,10 +12,10 @@ test_main (void)
   pid_t children[CHILD_CNT];
   int i;
 
-  for (i = 0; i < CHILD_CNT; i++) 
+  for (i = 0; i < CHILD_CNT; i++)
     CHECK ((children[i] = exec ("child-linear")) != -1,
            "exec \"child-linear\"");
 
-  for (i = 0; i < CHILD_CNT; i++) 
+  for (i = 0; i < CHILD_CNT; i++)
     CHECK (wait (children[i]) == 0x42, "wait for child %d", i);
 }

--- a/pintos/src/tests/vm/page-shuffle.c
+++ b/pintos/src/tests/vm/page-shuffle.c
@@ -20,7 +20,7 @@ test_main (void)
   for (i = 0; i < sizeof buf; i++)
     buf[i] = i * 257;
   msg ("init: cksum=%lu", cksum (buf, sizeof buf));
-    
+
   /* Shuffle repeatedly. */
   for (i = 0; i < 10; i++)
     {

--- a/pintos/src/tests/vm/parallel-merge.c
+++ b/pintos/src/tests/vm/parallel-merge.c
@@ -20,7 +20,7 @@ size_t histogram[256];
 /* Initialize buf1 with random data,
    then count the number of instances of each value within it. */
 static void
-init (void) 
+init (void)
 {
   struct arc4 arc4;
   size_t i;
@@ -41,7 +41,7 @@ sort_chunks (const char *subprocess, int exit_status)
   pid_t children[CHUNK_CNT];
   size_t i;
 
-  for (i = 0; i < CHUNK_CNT; i++) 
+  for (i = 0; i < CHUNK_CNT; i++)
     {
       char fn[128];
       char cmd[128];
@@ -63,7 +63,7 @@ sort_chunks (const char *subprocess, int exit_status)
       quiet = false;
     }
 
-  for (i = 0; i < CHUNK_CNT; i++) 
+  for (i = 0; i < CHUNK_CNT; i++)
     {
       char fn[128];
       int handle;
@@ -82,7 +82,7 @@ sort_chunks (const char *subprocess, int exit_status)
 
 /* Merge the sorted chunks in buf1 into a fully sorted buf2. */
 static void
-merge (void) 
+merge (void)
 {
   unsigned char *mp[CHUNK_CNT];
   size_t mp_left;
@@ -98,7 +98,7 @@ merge (void)
 
   /* Merge. */
   op = buf2;
-  while (mp_left > 0) 
+  while (mp_left > 0)
     {
       /* Find smallest value. */
       size_t min = 0;
@@ -111,13 +111,13 @@ merge (void)
 
       /* Advance merge pointer.
          Delete this chunk from the set if it's emptied. */
-      if ((++mp[min] - buf1) % CHUNK_SIZE == 0) 
+      if ((++mp[min] - buf1) % CHUNK_SIZE == 0)
         mp[min] = mp[--mp_left];
     }
 }
 
 static void
-verify (void) 
+verify (void)
 {
   size_t buf_idx;
   size_t hist_idx;
@@ -128,12 +128,12 @@ verify (void)
   for (hist_idx = 0; hist_idx < sizeof histogram / sizeof *histogram;
        hist_idx++)
     {
-      while (histogram[hist_idx]-- > 0) 
+      while (histogram[hist_idx]-- > 0)
         {
           if (buf2[buf_idx] != hist_idx)
             fail ("bad value %d in byte %zu", buf2[buf_idx], buf_idx);
           buf_idx++;
-        } 
+        }
     }
 
   msg ("success, buf_idx=%'zu", buf_idx);

--- a/pintos/src/tests/vm/qsort.c
+++ b/pintos/src/tests/vm/qsort.c
@@ -5,7 +5,7 @@
 
 /* Picks a pivot for the quicksort from the SIZE bytes in BUF. */
 static unsigned char
-pick_pivot (unsigned char *buf, size_t size) 
+pick_pivot (unsigned char *buf, size_t size)
 {
   ASSERT (size >= 1);
   return buf[random_ulong () % size];
@@ -17,10 +17,10 @@ pick_pivot (unsigned char *buf, size_t size)
    PIVOT. */
 static bool
 is_partitioned (const unsigned char *array, size_t size,
-                unsigned char pivot, size_t left_size) 
+                unsigned char pivot, size_t left_size)
 {
   size_t i;
-  
+
   for (i = 0; i < left_size; i++)
     if (array[i] >= pivot)
       return false;
@@ -34,7 +34,7 @@ is_partitioned (const unsigned char *array, size_t size,
 
 /* Swaps the bytes at *A and *B. */
 static void
-swap (unsigned char *a, unsigned char *b) 
+swap (unsigned char *a, unsigned char *b)
 {
   unsigned char t = *a;
   *a = *b;
@@ -45,7 +45,7 @@ swap (unsigned char *a, unsigned char *b)
    than PIVOT, followed by a run of bytes all greater than or
    equal to PIVOT.  Returns the length of the initial run. */
 static size_t
-partition (unsigned char *array, size_t size, int pivot) 
+partition (unsigned char *array, size_t size, int pivot)
 {
   size_t left_size = size;
   unsigned char *first = array;
@@ -97,7 +97,7 @@ partition (unsigned char *array, size_t size, int pivot)
 /* Returns true if the SIZE bytes in BUF are in nondecreasing
    order, false otherwise. */
 static bool
-is_sorted (const unsigned char *buf, size_t size) 
+is_sorted (const unsigned char *buf, size_t size)
 {
   size_t i;
 
@@ -111,9 +111,9 @@ is_sorted (const unsigned char *buf, size_t size)
 /* Sorts the SIZE bytes in BUF into nondecreasing order, using
    the quick-sort algorithm. */
 void
-qsort_bytes (unsigned char *buf, size_t size) 
+qsort_bytes (unsigned char *buf, size_t size)
 {
-  if (!is_sorted (buf, size)) 
+  if (!is_sorted (buf, size))
     {
       int pivot = pick_pivot (buf, size);
 
@@ -121,16 +121,16 @@ qsort_bytes (unsigned char *buf, size_t size)
       size_t left_size = partition (buf, size, pivot);
       unsigned char *right_half = left_half + left_size;
       size_t right_size = size - left_size;
-  
-      if (left_size <= right_size) 
+
+      if (left_size <= right_size)
         {
           qsort_bytes (left_half, left_size);
-          qsort_bytes (right_half, right_size); 
+          qsort_bytes (right_half, right_size);
         }
       else
         {
-          qsort_bytes (right_half, right_size); 
+          qsort_bytes (right_half, right_size);
           qsort_bytes (left_half, left_size);
         }
-    } 
+    }
 }

--- a/pintos/src/threads/fixed-point.h
+++ b/pintos/src/threads/fixed-point.h
@@ -13,7 +13,7 @@
 #define FIX_MAX_INT ((1 << FIX_P) - 1)  /* Largest representable integer. */
 
 /* A fixed-point number. */
-typedef struct 
+typedef struct
   {
     int f;
   }
@@ -21,7 +21,7 @@ fixed_point_t;
 
 /* Returns a fixed-point number with F as its internal value. */
 static inline fixed_point_t
-__mk_fix (int f) 
+__mk_fix (int f)
 {
   fixed_point_t x;
   x.f = f;
@@ -30,7 +30,7 @@ __mk_fix (int f)
 
 /* Returns fixed-point number corresponding to integer N. */
 static inline fixed_point_t
-fix_int (int n) 
+fix_int (int n)
 {
   ASSERT (n >= FIX_MIN_INT && n <= FIX_MAX_INT);
   return __mk_fix (n * FIX_F);
@@ -38,7 +38,7 @@ fix_int (int n)
 
 /* Returns fixed-point number corresponding to N divided by D. */
 static inline fixed_point_t
-fix_frac (int n, int d) 
+fix_frac (int n, int d)
 {
   ASSERT (d != 0);
   ASSERT (n / d >= FIX_MIN_INT && n / d <= FIX_MAX_INT);
@@ -47,42 +47,42 @@ fix_frac (int n, int d)
 
 /* Returns X rounded to the nearest integer. */
 static inline int
-fix_round (fixed_point_t x) 
+fix_round (fixed_point_t x)
 {
   return (x.f + FIX_F / 2) / FIX_F;
 }
 
 /* Returns X truncated down to the nearest integer. */
 static inline int
-fix_trunc (fixed_point_t x) 
+fix_trunc (fixed_point_t x)
 {
   return x.f / FIX_F;
 }
 
 /* Returns X + Y. */
 static inline fixed_point_t
-fix_add (fixed_point_t x, fixed_point_t y) 
+fix_add (fixed_point_t x, fixed_point_t y)
 {
   return __mk_fix (x.f + y.f);
 }
 
 /* Returns X - Y. */
 static inline fixed_point_t
-fix_sub (fixed_point_t x, fixed_point_t y) 
+fix_sub (fixed_point_t x, fixed_point_t y)
 {
   return __mk_fix (x.f - y.f);
 }
 
 /* Returns X * Y. */
 static inline fixed_point_t
-fix_mul (fixed_point_t x, fixed_point_t y) 
+fix_mul (fixed_point_t x, fixed_point_t y)
 {
   return __mk_fix ((long long) x.f * y.f / FIX_F);
 }
 
 /* Returns X * N. */
 static inline fixed_point_t
-fix_scale (fixed_point_t x, int n) 
+fix_scale (fixed_point_t x, int n)
 {
   ASSERT (n >= 0);
   return __mk_fix (x.f * n);
@@ -90,14 +90,14 @@ fix_scale (fixed_point_t x, int n)
 
 /* Returns X / Y. */
 static inline fixed_point_t
-fix_div (fixed_point_t x, fixed_point_t y) 
+fix_div (fixed_point_t x, fixed_point_t y)
 {
   return __mk_fix ((long long) x.f * FIX_F / y.f);
 }
 
 /* Returns X / N. */
 static inline fixed_point_t
-fix_unscale (fixed_point_t x, int n) 
+fix_unscale (fixed_point_t x, int n)
 {
   ASSERT (n > 0);
   return __mk_fix (x.f / n);
@@ -105,14 +105,14 @@ fix_unscale (fixed_point_t x, int n)
 
 /* Returns 1 / X. */
 static inline fixed_point_t
-fix_inv (fixed_point_t x) 
+fix_inv (fixed_point_t x)
 {
   return fix_div (fix_int (1), x);
 }
 
 /* Returns -1 if X < Y, 0 if X == Y, 1 if X > Y. */
 static inline int
-fix_compare (fixed_point_t x, fixed_point_t y) 
+fix_compare (fixed_point_t x, fixed_point_t y)
 {
   return x.f < y.f ? -1 : x.f > y.f;
 }

--- a/pintos/src/threads/init.c
+++ b/pintos/src/threads/init.c
@@ -78,7 +78,7 @@ main (void)
 {
   char **argv;
 
-  /* Clear BSS. */  
+  /* Clear BSS. */
   bss_init ();
 
   /* Break command line into arguments and parse options. */
@@ -88,7 +88,7 @@ main (void)
   /* Initialize ourselves as a thread so we can use locks,
      then enable console locking. */
   thread_init ();
-  console_init ();  
+  console_init ();
 
   /* Greet user. */
   printf ("Pintos booting with %'"PRIu32" kB RAM...\n",
@@ -128,7 +128,7 @@ main (void)
 #endif
 
   printf ("Boot complete.\n");
-  
+
   /* Run actions specified on kernel command line. */
   run_actions (argv);
 
@@ -136,7 +136,7 @@ main (void)
   shutdown ();
   thread_exit ();
 }
-
+
 /* Clear the "BSS", a segment that should be initialized to
    zeros.  It isn't actually stored on disk or zeroed by the
    kernel loader, so we have to zero it ourselves.
@@ -144,7 +144,7 @@ main (void)
    The start and end of the BSS segment is recorded by the
    linker as _start_bss and _end_bss.  See kernel.lds. */
 static void
-bss_init (void) 
+bss_init (void)
 {
   extern char _start_bss, _end_bss;
   memset (&_start_bss, 0, &_end_bss - &_start_bss);
@@ -191,7 +191,7 @@ paging_init (void)
 /* Breaks the kernel command line into words and returns them as
    an argv-like array. */
 static char **
-read_command_line (void) 
+read_command_line (void)
 {
   static char *argv[LOADER_ARGS_LEN / 2 + 1];
   char *p, *end;
@@ -201,7 +201,7 @@ read_command_line (void)
   argc = *(uint32_t *) ptov (LOADER_ARG_CNT);
   p = ptov (LOADER_ARGS);
   end = p + LOADER_ARGS_LEN;
-  for (i = 0; i < argc; i++) 
+  for (i = 0; i < argc; i++)
     {
       if (p >= end)
         PANIC ("command line arguments overflow");
@@ -226,14 +226,14 @@ read_command_line (void)
 /* Parses options in ARGV[]
    and returns the first non-option argument. */
 static char **
-parse_options (char **argv) 
+parse_options (char **argv)
 {
   for (; *argv != NULL && **argv == '-'; argv++)
     {
       char *save_ptr;
       char *name = strtok_r (*argv, "=", &save_ptr);
       char *value = strtok_r (NULL, "", &save_ptr);
-      
+
       if (!strcmp (name, "-h"))
         usage ();
       else if (!strcmp (name, "-q"))
@@ -273,7 +273,7 @@ parse_options (char **argv)
      for reproducibility.  To fix this, give the "-r" option to
      the pintos script to request real-time execution. */
   random_init (rtc_get_time ());
-  
+
   return argv;
 }
 
@@ -282,7 +282,7 @@ static void
 run_task (char **argv)
 {
   const char *task = argv[1];
-  
+
   printf ("Executing '%s':\n", task);
 #ifdef USERPROG
   process_wait (process_execute (task));
@@ -295,10 +295,10 @@ run_task (char **argv)
 /* Executes all of the actions specified in ARGV[]
    up to the null pointer sentinel. */
 static void
-run_actions (char **argv) 
+run_actions (char **argv)
 {
   /* An action. */
-  struct action 
+  struct action
     {
       char *name;                       /* Action name. */
       int argc;                         /* # of args, including action name. */
@@ -306,7 +306,7 @@ run_actions (char **argv)
     };
 
   /* Table of supported actions. */
-  static const struct action actions[] = 
+  static const struct action actions[] =
     {
       {"run", 2, run_task},
 #ifdef FILESYS
@@ -340,7 +340,7 @@ run_actions (char **argv)
       a->function (argv);
       argv += a->argc;
     }
-  
+
 }
 
 /* Prints a kernel command line help message and powers off the

--- a/pintos/src/threads/interrupt.c
+++ b/pintos/src/threads/interrupt.c
@@ -59,10 +59,10 @@ static inline uint64_t make_idtr_operand (uint16_t limit, void *base);
 /* Interrupt handlers. */
 void intr_handler (struct intr_frame *args);
 static void unexpected_interrupt (const struct intr_frame *);
-
+
 /* Returns the current interrupt status. */
 enum intr_level
-intr_get_level (void) 
+intr_get_level (void)
 {
   uint32_t flags;
 
@@ -78,14 +78,14 @@ intr_get_level (void)
 /* Enables or disables interrupts as specified by LEVEL and
    returns the previous interrupt status. */
 enum intr_level
-intr_set_level (enum intr_level level) 
+intr_set_level (enum intr_level level)
 {
   return level == INTR_ON ? intr_enable () : intr_disable ();
 }
 
 /* Enables interrupts and returns the previous interrupt status. */
 enum intr_level
-intr_enable (void) 
+intr_enable (void)
 {
   enum intr_level old_level = intr_get_level ();
   ASSERT (!intr_context ());
@@ -101,7 +101,7 @@ intr_enable (void)
 
 /* Disables interrupts and returns the previous interrupt status. */
 enum intr_level
-intr_disable (void) 
+intr_disable (void)
 {
   enum intr_level old_level = intr_get_level ();
 
@@ -112,7 +112,7 @@ intr_disable (void)
 
   return old_level;
 }
-
+
 /* Initializes the interrupt system. */
 void
 intr_init (void)
@@ -179,7 +179,7 @@ register_handler (uint8_t vec_no, int dpl, enum intr_level level,
    execute with interrupts disabled. */
 void
 intr_register_ext (uint8_t vec_no, intr_handler_func *handler,
-                   const char *name) 
+                   const char *name)
 {
   ASSERT (vec_no >= 0x20 && vec_no <= 0x2f);
   register_handler (vec_no, 0, INTR_OFF, handler, name);
@@ -209,7 +209,7 @@ intr_register_int (uint8_t vec_no, int dpl, enum intr_level level,
 /* Returns true during processing of an external interrupt
    and false at all other times. */
 bool
-intr_context (void) 
+intr_context (void)
 {
   return in_external_intr;
 }
@@ -219,12 +219,12 @@ intr_context (void)
    returning from the interrupt.  May not be called at any other
    time. */
 void
-intr_yield_on_return (void) 
+intr_yield_on_return (void)
 {
   ASSERT (intr_context ());
   yield_on_return = true;
 }
-
+
 /* 8259A Programmable Interrupt Controller. */
 
 /* Initializes the PICs.  Refer to [8259A] for details.
@@ -262,7 +262,7 @@ pic_init (void)
    If we don't acknowledge the IRQ, it will never be delivered to
    us again, so this is important.  */
 static void
-pic_end_of_interrupt (int irq) 
+pic_end_of_interrupt (int irq)
 {
   ASSERT (irq >= 0x20 && irq < 0x30);
 
@@ -273,7 +273,7 @@ pic_end_of_interrupt (int irq)
   if (irq >= 0x28)
     outb (0xa0, 0x20);
 }
-
+
 /* Creates an gate that invokes FUNCTION.
 
    The gate has descriptor privilege level DPL, meaning that it
@@ -334,7 +334,7 @@ make_idtr_operand (uint16_t limit, void *base)
 {
   return limit | ((uint64_t) (uint32_t) base << 16);
 }
-
+
 /* Interrupt handlers. */
 
 /* Handler for all interrupts, faults, and exceptions.  This
@@ -342,7 +342,7 @@ make_idtr_operand (uint16_t limit, void *base)
    intr-stubs.S.  FRAME describes the interrupt and the
    interrupted thread's registers. */
 void
-intr_handler (struct intr_frame *frame) 
+intr_handler (struct intr_frame *frame)
 {
   bool external;
   intr_handler_func *handler;
@@ -352,7 +352,7 @@ intr_handler (struct intr_frame *frame)
      and they need to be acknowledged on the PIC (see below).
      An external interrupt handler cannot sleep. */
   external = frame->vec_no >= 0x20 && frame->vec_no < 0x30;
-  if (external) 
+  if (external)
     {
       ASSERT (intr_get_level () == INTR_OFF);
       ASSERT (!intr_context ());
@@ -375,16 +375,16 @@ intr_handler (struct intr_frame *frame)
     unexpected_interrupt (frame);
 
   /* Complete the processing of an external interrupt. */
-  if (external) 
+  if (external)
     {
       ASSERT (intr_get_level () == INTR_OFF);
       ASSERT (intr_context ());
 
       in_external_intr = false;
-      pic_end_of_interrupt (frame->vec_no); 
+      pic_end_of_interrupt (frame->vec_no);
 
-      if (yield_on_return) 
-        thread_yield (); 
+      if (yield_on_return)
+        thread_yield ();
     }
 }
 
@@ -408,7 +408,7 @@ unexpected_interrupt (const struct intr_frame *f)
 
 /* Dumps interrupt frame F to the console, for debugging. */
 void
-intr_dump_frame (const struct intr_frame *f) 
+intr_dump_frame (const struct intr_frame *f)
 {
   uint32_t cr2;
 
@@ -432,7 +432,7 @@ intr_dump_frame (const struct intr_frame *f)
 
 /* Returns the name of interrupt VEC. */
 const char *
-intr_name (uint8_t vec) 
+intr_name (uint8_t vec)
 {
   return intr_names[vec];
 }

--- a/pintos/src/threads/interrupt.h
+++ b/pintos/src/threads/interrupt.h
@@ -5,7 +5,7 @@
 #include <stdint.h>
 
 /* Interrupts on or off? */
-enum intr_level 
+enum intr_level
   {
     INTR_OFF,             /* Interrupts disabled. */
     INTR_ON               /* Interrupts enabled. */
@@ -15,7 +15,7 @@ enum intr_level intr_get_level (void);
 enum intr_level intr_set_level (enum intr_level);
 enum intr_level intr_enable (void);
 enum intr_level intr_disable (void);
-
+
 /* Interrupt stack frame. */
 struct intr_frame
   {

--- a/pintos/src/threads/malloc.c
+++ b/pintos/src/threads/malloc.c
@@ -47,7 +47,7 @@ struct desc
 #define ARENA_MAGIC 0x9a548eed
 
 /* Arena. */
-struct arena 
+struct arena
   {
     unsigned magic;             /* Always set to ARENA_MAGIC. */
     struct desc *desc;          /* Owning descriptor, null for big block. */
@@ -55,7 +55,7 @@ struct arena
   };
 
 /* Free block. */
-struct block 
+struct block
   {
     struct list_elem free_elem; /* Free list element. */
   };
@@ -69,7 +69,7 @@ static struct block *arena_to_block (struct arena *, size_t idx);
 
 /* Initializes the malloc() descriptors. */
 void
-malloc_init (void) 
+malloc_init (void)
 {
   size_t block_size;
 
@@ -87,7 +87,7 @@ malloc_init (void)
 /* Obtains and returns a new block of at least SIZE bytes.
    Returns a null pointer if memory is not available. */
 void *
-malloc (size_t size) 
+malloc (size_t size)
 {
   struct desc *d;
   struct block *b;
@@ -102,7 +102,7 @@ malloc (size_t size)
   for (d = descs; d < descs + desc_cnt; d++)
     if (d->block_size >= size)
       break;
-  if (d == descs + desc_cnt) 
+  if (d == descs + desc_cnt)
     {
       /* SIZE is too big for any descriptor.
          Allocate enough pages to hold SIZE plus an arena. */
@@ -128,17 +128,17 @@ malloc (size_t size)
 
       /* Allocate a page. */
       a = palloc_get_page (0);
-      if (a == NULL) 
+      if (a == NULL)
         {
           lock_release (&d->lock);
-          return NULL; 
+          return NULL;
         }
 
       /* Initialize arena and add its blocks to the free list. */
       a->magic = ARENA_MAGIC;
       a->desc = d;
       a->free_cnt = d->blocks_per_arena;
-      for (i = 0; i < d->blocks_per_arena; i++) 
+      for (i = 0; i < d->blocks_per_arena; i++)
         {
           struct block *b = arena_to_block (a, i);
           list_push_back (&d->free_list, &b->free_elem);
@@ -156,7 +156,7 @@ malloc (size_t size)
 /* Allocates and return A times B bytes initialized to zeroes.
    Returns a null pointer if memory is not available. */
 void *
-calloc (size_t a, size_t b) 
+calloc (size_t a, size_t b)
 {
   void *p;
   size_t size;
@@ -176,7 +176,7 @@ calloc (size_t a, size_t b)
 
 /* Returns the number of bytes allocated for BLOCK. */
 static size_t
-block_size (void *block) 
+block_size (void *block)
 {
   struct block *b = block;
   struct arena *a = block_to_arena (b);
@@ -192,14 +192,14 @@ block_size (void *block)
    A call with null OLD_BLOCK is equivalent to malloc(NEW_SIZE).
    A call with zero NEW_SIZE is equivalent to free(OLD_BLOCK). */
 void *
-realloc (void *old_block, size_t new_size) 
+realloc (void *old_block, size_t new_size)
 {
-  if (new_size == 0) 
+  if (new_size == 0)
     {
       free (old_block);
       return NULL;
     }
-  else 
+  else
     {
       void *new_block = malloc (new_size);
       if (old_block != NULL && new_block != NULL)
@@ -216,15 +216,15 @@ realloc (void *old_block, size_t new_size)
 /* Frees block P, which must have been previously allocated with
    malloc(), calloc(), or realloc(). */
 void
-free (void *p) 
+free (void *p)
 {
   if (p != NULL)
     {
       struct block *b = p;
       struct arena *a = block_to_arena (b);
       struct desc *d = a->desc;
-      
-      if (d != NULL) 
+
+      if (d != NULL)
         {
           /* It's a normal block.  We handle it here. */
 
@@ -232,19 +232,19 @@ free (void *p)
           /* Clear the block to help detect use-after-free bugs. */
           memset (b, 0xcc, d->block_size);
 #endif
-  
+
           lock_acquire (&d->lock);
 
           /* Add block to free list. */
           list_push_front (&d->free_list, &b->free_elem);
 
           /* If the arena is now entirely unused, free it. */
-          if (++a->free_cnt >= d->blocks_per_arena) 
+          if (++a->free_cnt >= d->blocks_per_arena)
             {
               size_t i;
 
               ASSERT (a->free_cnt == d->blocks_per_arena);
-              for (i = 0; i < d->blocks_per_arena; i++) 
+              for (i = 0; i < d->blocks_per_arena; i++)
                 {
                   struct block *b = arena_to_block (a, i);
                   list_remove (&b->free_elem);
@@ -262,7 +262,7 @@ free (void *p)
         }
     }
 }
-
+
 /* Returns the arena that block B is inside. */
 static struct arena *
 block_to_arena (struct block *b)
@@ -283,7 +283,7 @@ block_to_arena (struct block *b)
 
 /* Returns the (IDX - 1)'th block within arena A. */
 static struct block *
-arena_to_block (struct arena *a, size_t idx) 
+arena_to_block (struct arena *a, size_t idx)
 {
   ASSERT (a != NULL);
   ASSERT (a->magic == ARENA_MAGIC);

--- a/pintos/src/threads/palloc.c
+++ b/pintos/src/threads/palloc.c
@@ -86,12 +86,12 @@ palloc_get_multiple (enum palloc_flags flags, size_t page_cnt)
   else
     pages = NULL;
 
-  if (pages != NULL) 
+  if (pages != NULL)
     {
       if (flags & PAL_ZERO)
         memset (pages, 0, PGSIZE * page_cnt);
     }
-  else 
+  else
     {
       if (flags & PAL_ASSERT)
         PANIC ("palloc_get: out of pages");
@@ -108,14 +108,14 @@ palloc_get_multiple (enum palloc_flags flags, size_t page_cnt)
    available, returns a null pointer, unless PAL_ASSERT is set in
    FLAGS, in which case the kernel panics. */
 void *
-palloc_get_page (enum palloc_flags flags) 
+palloc_get_page (enum palloc_flags flags)
 {
   return palloc_get_multiple (flags, 1);
 }
 
 /* Frees the PAGE_CNT pages starting at PAGES. */
 void
-palloc_free_multiple (void *pages, size_t page_cnt) 
+palloc_free_multiple (void *pages, size_t page_cnt)
 {
   struct pool *pool;
   size_t page_idx;
@@ -143,7 +143,7 @@ palloc_free_multiple (void *pages, size_t page_cnt)
 
 /* Frees the page at PAGE. */
 void
-palloc_free_page (void *page) 
+palloc_free_page (void *page)
 {
   palloc_free_multiple (page, 1);
 }
@@ -151,7 +151,7 @@ palloc_free_page (void *page)
 /* Initializes pool P as starting at START and ending at END,
    naming it NAME for debugging purposes. */
 static void
-init_pool (struct pool *p, void *base, size_t page_cnt, const char *name) 
+init_pool (struct pool *p, void *base, size_t page_cnt, const char *name)
 {
   /* We'll put the pool's used_map at its base.
      Calculate the space needed for the bitmap
@@ -172,7 +172,7 @@ init_pool (struct pool *p, void *base, size_t page_cnt, const char *name)
 /* Returns true if PAGE was allocated from POOL,
    false otherwise. */
 static bool
-page_from_pool (const struct pool *pool, void *page) 
+page_from_pool (const struct pool *pool, void *page)
 {
   size_t page_no = pg_no (page);
   size_t start_page = pg_no (pool->base);

--- a/pintos/src/threads/pte.h
+++ b/pintos/src/threads/pte.h
@@ -8,7 +8,7 @@
 
    See vaddr.h for more generic functions and macros for virtual
    addresses.
-   
+
    Virtual addresses are structured as follows:
 
     31                  22 21                  12 11                   0

--- a/pintos/src/threads/switch.h
+++ b/pintos/src/threads/switch.h
@@ -3,7 +3,7 @@
 
 #ifndef __ASSEMBLER__
 /* switch_thread()'s stack frame. */
-struct switch_threads_frame 
+struct switch_threads_frame
   {
     uint32_t edi;               /*  0: Saved %edi. */
     uint32_t esi;               /*  4: Saved %esi. */

--- a/pintos/src/threads/synch.c
+++ b/pintos/src/threads/synch.c
@@ -42,7 +42,7 @@
    - up or "V": increment the value (and wake up one waiting
      thread, if any). */
 void
-sema_init (struct semaphore *sema, unsigned value) 
+sema_init (struct semaphore *sema, unsigned value)
 {
   ASSERT (sema != NULL);
 
@@ -58,7 +58,7 @@ sema_init (struct semaphore *sema, unsigned value)
    interrupts disabled, but if it sleeps then the next scheduled
    thread will probably turn interrupts back on. */
 void
-sema_down (struct semaphore *sema) 
+sema_down (struct semaphore *sema)
 {
   enum intr_level old_level;
 
@@ -66,7 +66,7 @@ sema_down (struct semaphore *sema)
   ASSERT (!intr_context ());
 
   old_level = intr_disable ();
-  while (sema->value == 0) 
+  while (sema->value == 0)
     {
       list_push_back (&sema->waiters, &thread_current ()->elem);
       thread_block ();
@@ -81,7 +81,7 @@ sema_down (struct semaphore *sema)
 
    This function may be called from an interrupt handler. */
 bool
-sema_try_down (struct semaphore *sema) 
+sema_try_down (struct semaphore *sema)
 {
   enum intr_level old_level;
   bool success;
@@ -89,10 +89,10 @@ sema_try_down (struct semaphore *sema)
   ASSERT (sema != NULL);
 
   old_level = intr_disable ();
-  if (sema->value > 0) 
+  if (sema->value > 0)
     {
       sema->value--;
-      success = true; 
+      success = true;
     }
   else
     success = false;
@@ -106,14 +106,14 @@ sema_try_down (struct semaphore *sema)
 
    This function may be called from an interrupt handler. */
 void
-sema_up (struct semaphore *sema) 
+sema_up (struct semaphore *sema)
 {
   enum intr_level old_level;
 
   ASSERT (sema != NULL);
 
   old_level = intr_disable ();
-  if (!list_empty (&sema->waiters)) 
+  if (!list_empty (&sema->waiters))
     thread_unblock (list_entry (list_pop_front (&sema->waiters),
                                 struct thread, elem));
   sema->value++;
@@ -126,7 +126,7 @@ static void sema_test_helper (void *sema_);
    between a pair of threads.  Insert calls to printf() to see
    what's going on. */
 void
-sema_self_test (void) 
+sema_self_test (void)
 {
   struct semaphore sema[2];
   int i;
@@ -135,7 +135,7 @@ sema_self_test (void)
   sema_init (&sema[0], 0);
   sema_init (&sema[1], 0);
   thread_create ("sema-test", PRI_DEFAULT, sema_test_helper, &sema);
-  for (i = 0; i < 10; i++) 
+  for (i = 0; i < 10; i++)
     {
       sema_up (&sema[0]);
       sema_down (&sema[1]);
@@ -145,18 +145,18 @@ sema_self_test (void)
 
 /* Thread function used by sema_self_test(). */
 static void
-sema_test_helper (void *sema_) 
+sema_test_helper (void *sema_)
 {
   struct semaphore *sema = sema_;
   int i;
 
-  for (i = 0; i < 10; i++) 
+  for (i = 0; i < 10; i++)
     {
       sema_down (&sema[0]);
       sema_up (&sema[1]);
     }
 }
-
+
 /* Initializes LOCK.  A lock can be held by at most a single
    thread at any given time.  Our locks are not "recursive", that
    is, it is an error for the thread currently holding a lock to
@@ -226,7 +226,7 @@ lock_try_acquire (struct lock *lock)
    make sense to try to release a lock within an interrupt
    handler. */
 void
-lock_release (struct lock *lock) 
+lock_release (struct lock *lock)
 {
   ASSERT (lock != NULL);
   ASSERT (lock_held_by_current_thread (lock));
@@ -239,15 +239,15 @@ lock_release (struct lock *lock)
    otherwise.  (Note that testing whether some other thread holds
    a lock would be racy.) */
 bool
-lock_held_by_current_thread (const struct lock *lock) 
+lock_held_by_current_thread (const struct lock *lock)
 {
   ASSERT (lock != NULL);
 
   return lock->holder == thread_current ();
 }
-
+
 /* One semaphore in a list. */
-struct semaphore_elem 
+struct semaphore_elem
   {
     struct list_elem elem;              /* List element. */
     struct semaphore semaphore;         /* This semaphore. */
@@ -285,7 +285,7 @@ cond_init (struct condition *cond)
    interrupts disabled, but interrupts will be turned back on if
    we need to sleep. */
 void
-cond_wait (struct condition *cond, struct lock *lock) 
+cond_wait (struct condition *cond, struct lock *lock)
 {
   struct semaphore_elem waiter;
 
@@ -293,7 +293,7 @@ cond_wait (struct condition *cond, struct lock *lock)
   ASSERT (lock != NULL);
   ASSERT (!intr_context ());
   ASSERT (lock_held_by_current_thread (lock));
-  
+
   sema_init (&waiter.semaphore, 0);
   list_push_back (&cond->waiters, &waiter.elem);
   lock_release (lock);
@@ -309,14 +309,14 @@ cond_wait (struct condition *cond, struct lock *lock)
    make sense to try to signal a condition variable within an
    interrupt handler. */
 void
-cond_signal (struct condition *cond, struct lock *lock UNUSED) 
+cond_signal (struct condition *cond, struct lock *lock UNUSED)
 {
   ASSERT (cond != NULL);
   ASSERT (lock != NULL);
   ASSERT (!intr_context ());
   ASSERT (lock_held_by_current_thread (lock));
 
-  if (!list_empty (&cond->waiters)) 
+  if (!list_empty (&cond->waiters))
     sema_up (&list_entry (list_pop_front (&cond->waiters),
                           struct semaphore_elem, elem)->semaphore);
 }
@@ -328,7 +328,7 @@ cond_signal (struct condition *cond, struct lock *lock UNUSED)
    make sense to try to signal a condition variable within an
    interrupt handler. */
 void
-cond_broadcast (struct condition *cond, struct lock *lock) 
+cond_broadcast (struct condition *cond, struct lock *lock)
 {
   ASSERT (cond != NULL);
   ASSERT (lock != NULL);

--- a/pintos/src/threads/synch.h
+++ b/pintos/src/threads/synch.h
@@ -5,7 +5,7 @@
 #include <stdbool.h>
 
 /* A counting semaphore. */
-struct semaphore 
+struct semaphore
   {
     unsigned value;             /* Current value. */
     struct list waiters;        /* List of waiting threads. */
@@ -18,7 +18,7 @@ void sema_up (struct semaphore *);
 void sema_self_test (void);
 
 /* Lock. */
-struct lock 
+struct lock
   {
     struct thread *holder;      /* Thread holding lock (for debugging). */
     struct semaphore semaphore; /* Binary semaphore controlling access. */
@@ -31,7 +31,7 @@ void lock_release (struct lock *);
 bool lock_held_by_current_thread (const struct lock *);
 
 /* Condition variable. */
-struct condition 
+struct condition
   {
     struct list waiters;        /* List of waiting threads. */
   };

--- a/pintos/src/threads/thread.c
+++ b/pintos/src/threads/thread.c
@@ -38,7 +38,7 @@ static struct thread *initial_thread;
 static struct lock tid_lock;
 
 /* Stack frame for kernel_thread(). */
-struct kernel_thread_frame 
+struct kernel_thread_frame
   {
     void *eip;                  /* Return address. */
     thread_func *function;      /* Function to call. */
@@ -85,7 +85,7 @@ static tid_t allocate_tid (void);
    It is not safe to call thread_current() until this function
    finishes. */
 void
-thread_init (void) 
+thread_init (void)
 {
   ASSERT (intr_get_level () == INTR_OFF);
 
@@ -103,7 +103,7 @@ thread_init (void)
 /* Starts preemptive thread scheduling by enabling interrupts.
    Also creates the idle thread. */
 void
-thread_start (void) 
+thread_start (void)
 {
   /* Create the idle thread. */
   struct semaphore idle_started;
@@ -120,7 +120,7 @@ thread_start (void)
 /* Called by the timer interrupt handler at each timer tick.
    Thus, this function runs in an external interrupt context. */
 void
-thread_tick (void) 
+thread_tick (void)
 {
   struct thread *t = thread_current ();
 
@@ -141,7 +141,7 @@ thread_tick (void)
 
 /* Prints thread statistics. */
 void
-thread_print_stats (void) 
+thread_print_stats (void)
 {
   printf ("Thread: %lld idle ticks, %lld kernel ticks, %lld user ticks\n",
           idle_ticks, kernel_ticks, user_ticks);
@@ -164,7 +164,7 @@ thread_print_stats (void)
    Priority scheduling is the goal of Problem 1-3. */
 tid_t
 thread_create (const char *name, int priority,
-               thread_func *function, void *aux) 
+               thread_func *function, void *aux)
 {
   struct thread *t;
   struct kernel_thread_frame *kf;
@@ -211,7 +211,7 @@ thread_create (const char *name, int priority,
    is usually a better idea to use one of the synchronization
    primitives in synch.h. */
 void
-thread_block (void) 
+thread_block (void)
 {
   ASSERT (!intr_context ());
   ASSERT (intr_get_level () == INTR_OFF);
@@ -229,7 +229,7 @@ thread_block (void)
    it may expect that it can atomically unblock a thread and
    update other data. */
 void
-thread_unblock (struct thread *t) 
+thread_unblock (struct thread *t)
 {
   enum intr_level old_level;
 
@@ -244,7 +244,7 @@ thread_unblock (struct thread *t)
 
 /* Returns the name of the running thread. */
 const char *
-thread_name (void) 
+thread_name (void)
 {
   return thread_current ()->name;
 }
@@ -253,10 +253,10 @@ thread_name (void)
    This is running_thread() plus a couple of sanity checks.
    See the big comment at the top of thread.h for details. */
 struct thread *
-thread_current (void) 
+thread_current (void)
 {
   struct thread *t = running_thread ();
-  
+
   /* Make sure T is really a thread.
      If either of these assertions fire, then your thread may
      have overflowed its stack.  Each thread has less than 4 kB
@@ -270,7 +270,7 @@ thread_current (void)
 
 /* Returns the running thread's tid. */
 tid_t
-thread_tid (void) 
+thread_tid (void)
 {
   return thread_current ()->tid;
 }
@@ -278,7 +278,7 @@ thread_tid (void)
 /* Deschedules the current thread and destroys it.  Never
    returns to the caller. */
 void
-thread_exit (void) 
+thread_exit (void)
 {
   ASSERT (!intr_context ());
 
@@ -299,15 +299,15 @@ thread_exit (void)
 /* Yields the CPU.  The current thread is not put to sleep and
    may be scheduled again immediately at the scheduler's whim. */
 void
-thread_yield (void) 
+thread_yield (void)
 {
   struct thread *cur = thread_current ();
   enum intr_level old_level;
-  
+
   ASSERT (!intr_context ());
 
   old_level = intr_disable ();
-  if (cur != idle_thread) 
+  if (cur != idle_thread)
     list_push_back (&ready_list, &cur->elem);
   cur->status = THREAD_READY;
   schedule ();
@@ -333,28 +333,28 @@ thread_foreach (thread_action_func *func, void *aux)
 
 /* Sets the current thread's priority to NEW_PRIORITY. */
 void
-thread_set_priority (int new_priority) 
+thread_set_priority (int new_priority)
 {
   thread_current ()->priority = new_priority;
 }
 
 /* Returns the current thread's priority. */
 int
-thread_get_priority (void) 
+thread_get_priority (void)
 {
   return thread_current ()->priority;
 }
 
 /* Sets the current thread's nice value to NICE. */
 void
-thread_set_nice (int nice UNUSED) 
+thread_set_nice (int nice UNUSED)
 {
   /* Not yet implemented. */
 }
 
 /* Returns the current thread's nice value. */
 int
-thread_get_nice (void) 
+thread_get_nice (void)
 {
   /* Not yet implemented. */
   return 0;
@@ -362,7 +362,7 @@ thread_get_nice (void)
 
 /* Returns 100 times the system load average. */
 int
-thread_get_load_avg (void) 
+thread_get_load_avg (void)
 {
   /* Not yet implemented. */
   return 0;
@@ -370,12 +370,12 @@ thread_get_load_avg (void)
 
 /* Returns 100 times the current thread's recent_cpu value. */
 int
-thread_get_recent_cpu (void) 
+thread_get_recent_cpu (void)
 {
   /* Not yet implemented. */
   return 0;
 }
-
+
 /* Idle thread.  Executes when no other thread is ready to run.
 
    The idle thread is initially put on the ready list by
@@ -386,13 +386,13 @@ thread_get_recent_cpu (void)
    ready list.  It is returned by next_thread_to_run() as a
    special case when the ready list is empty. */
 static void
-idle (void *idle_started_ UNUSED) 
+idle (void *idle_started_ UNUSED)
 {
   struct semaphore *idle_started = idle_started_;
   idle_thread = thread_current ();
   sema_up (idle_started);
 
-  for (;;) 
+  for (;;)
     {
       /* Let someone else run. */
       intr_disable ();
@@ -416,7 +416,7 @@ idle (void *idle_started_ UNUSED)
 
 /* Function used as the basis for a kernel thread. */
 static void
-kernel_thread (thread_func *function, void *aux) 
+kernel_thread (thread_func *function, void *aux)
 {
   ASSERT (function != NULL);
 
@@ -424,10 +424,10 @@ kernel_thread (thread_func *function, void *aux)
   function (aux);       /* Execute the thread function. */
   thread_exit ();       /* If function() returns, kill the thread. */
 }
-
+
 /* Returns the running thread. */
 struct thread *
-running_thread (void) 
+running_thread (void)
 {
   uint32_t *esp;
 
@@ -472,7 +472,7 @@ init_thread (struct thread *t, const char *name, int priority)
 /* Allocates a SIZE-byte frame at the top of thread T's stack and
    returns a pointer to the frame's base. */
 static void *
-alloc_frame (struct thread *t, size_t size) 
+alloc_frame (struct thread *t, size_t size)
 {
   /* Stack data is always allocated in word-size units. */
   ASSERT (is_thread (t));
@@ -488,7 +488,7 @@ alloc_frame (struct thread *t, size_t size)
    will be in the run queue.)  If the run queue is empty, return
    idle_thread. */
 static struct thread *
-next_thread_to_run (void) 
+next_thread_to_run (void)
 {
   if (list_empty (&ready_list))
     return idle_thread;
@@ -516,7 +516,7 @@ void
 thread_schedule_tail (struct thread *prev)
 {
   struct thread *cur = running_thread ();
-  
+
   ASSERT (intr_get_level () == INTR_OFF);
 
   /* Mark us as running. */
@@ -535,7 +535,7 @@ thread_schedule_tail (struct thread *prev)
      pull out the rug under itself.  (We don't free
      initial_thread because its memory was not obtained via
      palloc().) */
-  if (prev != NULL && prev->status == THREAD_DYING && prev != initial_thread) 
+  if (prev != NULL && prev->status == THREAD_DYING && prev != initial_thread)
     {
       ASSERT (prev != cur);
       palloc_free_page (prev);
@@ -550,7 +550,7 @@ thread_schedule_tail (struct thread *prev)
    It's not safe to call printf() until thread_schedule_tail()
    has completed. */
 static void
-schedule (void) 
+schedule (void)
 {
   struct thread *cur = running_thread ();
   struct thread *next = next_thread_to_run ();
@@ -567,7 +567,7 @@ schedule (void)
 
 /* Returns a tid to use for a new thread. */
 static tid_t
-allocate_tid (void) 
+allocate_tid (void)
 {
   static tid_t next_tid = 1;
   tid_t tid;
@@ -578,7 +578,7 @@ allocate_tid (void)
 
   return tid;
 }
-
+
 /* Offset of `stack' member within `struct thread'.
    Used by switch.S, which can't figure it out on its own. */
 uint32_t thread_stack_ofs = offsetof (struct thread, stack);

--- a/pintos/src/threads/vaddr.h
+++ b/pintos/src/threads/vaddr.h
@@ -39,7 +39,7 @@ static inline void *pg_round_up (const void *va) {
 static inline void *pg_round_down (const void *va) {
   return (void *) ((uintptr_t) va & ~PGMASK);
 }
-
+
 /* Base address of the 1:1 physical-to-virtual mapping.  Physical
    memory is mapped starting at this virtual address.  Thus,
    physical address 0 is accessible at PHYS_BASE, physical
@@ -54,14 +54,14 @@ static inline void *pg_round_down (const void *va) {
 
 /* Returns true if VADDR is a user virtual address. */
 static inline bool
-is_user_vaddr (const void *vaddr) 
+is_user_vaddr (const void *vaddr)
 {
   return vaddr < PHYS_BASE;
 }
 
 /* Returns true if VADDR is a kernel virtual address. */
 static inline bool
-is_kernel_vaddr (const void *vaddr) 
+is_kernel_vaddr (const void *vaddr)
 {
   return vaddr >= PHYS_BASE;
 }

--- a/pintos/src/userprog/exception.c
+++ b/pintos/src/userprog/exception.c
@@ -27,7 +27,7 @@ static void page_fault (struct intr_frame *);
    Refer to [IA32-v3a] section 5.15 "Exception and Interrupt
    Reference" for a description of each of these exceptions. */
 void
-exception_init (void) 
+exception_init (void)
 {
   /* These exceptions can be raised explicitly by a user program,
      e.g. via the INT, INT3, INTO, and BOUND instructions.  Thus,
@@ -62,14 +62,14 @@ exception_init (void)
 
 /* Prints exception statistics. */
 void
-exception_print_stats (void) 
+exception_print_stats (void)
 {
   printf ("Exception: %lld page faults\n", page_fault_cnt);
 }
 
 /* Handler for an exception (probably) caused by a user process. */
 static void
-kill (struct intr_frame *f) 
+kill (struct intr_frame *f)
 {
   /* This interrupt is one (probably) caused by a user process.
      For example, the process might have tried to access unmapped
@@ -78,7 +78,7 @@ kill (struct intr_frame *f)
      the kernel.  Real Unix-like operating systems pass most
      exceptions back to the process via signals, but we don't
      implement them. */
-     
+
   /* The interrupt frame's code segment value tells us where the
      exception originated. */
   switch (f->cs)
@@ -89,7 +89,7 @@ kill (struct intr_frame *f)
       printf ("%s: dying due to interrupt %#04x (%s).\n",
               thread_name (), f->vec_no, intr_name (f->vec_no));
       intr_dump_frame (f);
-      thread_exit (); 
+      thread_exit ();
 
     case SEL_KCSEG:
       /* Kernel's code segment, which indicates a kernel bug.
@@ -97,7 +97,7 @@ kill (struct intr_frame *f)
          may cause kernel exceptions--but they shouldn't arrive
          here.)  Panic the kernel to make the point.  */
       intr_dump_frame (f);
-      PANIC ("Kernel bug - unexpected interrupt in kernel"); 
+      PANIC ("Kernel bug - unexpected interrupt in kernel");
 
     default:
       /* Some other code segment?  Shouldn't happen.  Panic the
@@ -120,7 +120,7 @@ kill (struct intr_frame *f)
    description of "Interrupt 14--Page Fault Exception (#PF)" in
    [IA32-v3a] section 5.15 "Exception and Interrupt Reference". */
 static void
-page_fault (struct intr_frame *f) 
+page_fault (struct intr_frame *f)
 {
   bool not_present;  /* True: not-present page, false: writing r/o page. */
   bool write;        /* True: access was write, false: access was read. */

--- a/pintos/src/userprog/gdt.c
+++ b/pintos/src/userprog/gdt.c
@@ -52,7 +52,7 @@ gdt_init (void)
   asm volatile ("lgdt %0" : : "m" (gdtr_operand));
   asm volatile ("ltr %w0" : : "q" (SEL_TSS));
 }
-
+
 /* System segment or code/data segment? */
 enum seg_class
   {

--- a/pintos/src/userprog/pagedir.c
+++ b/pintos/src/userprog/pagedir.c
@@ -14,7 +14,7 @@ static void invalidate_pagedir (uint32_t *);
    Returns the new page directory, or a null pointer if memory
    allocation fails. */
 uint32_t *
-pagedir_create (void) 
+pagedir_create (void)
 {
   uint32_t *pd = palloc_get_page (0);
   if (pd != NULL)
@@ -25,7 +25,7 @@ pagedir_create (void)
 /* Destroys page directory PD, freeing all the pages it
    references. */
 void
-pagedir_destroy (uint32_t *pd) 
+pagedir_destroy (uint32_t *pd)
 {
   uint32_t *pde;
 
@@ -34,13 +34,13 @@ pagedir_destroy (uint32_t *pd)
 
   ASSERT (pd != init_page_dir);
   for (pde = pd; pde < pd + pd_no (PHYS_BASE); pde++)
-    if (*pde & PTE_P) 
+    if (*pde & PTE_P)
       {
         uint32_t *pt = pde_get_pt (*pde);
         uint32_t *pte;
-        
+
         for (pte = pt; pte < pt + PGSIZE / sizeof *pte; pte++)
-          if (*pte & PTE_P) 
+          if (*pte & PTE_P)
             palloc_free_page (pte_get_page (*pte));
         palloc_free_page (pt);
       }
@@ -66,14 +66,14 @@ lookup_page (uint32_t *pd, const void *vaddr, bool create)
   /* Check for a page table for VADDR.
      If one is missing, create one if requested. */
   pde = pd + pd_no (vaddr);
-  if (*pde == 0) 
+  if (*pde == 0)
     {
       if (create)
         {
           pt = palloc_get_page (PAL_ZERO);
-          if (pt == NULL) 
-            return NULL; 
-      
+          if (pt == NULL)
+            return NULL;
+
           *pde = pde_create (pt);
         }
       else
@@ -108,7 +108,7 @@ pagedir_set_page (uint32_t *pd, void *upage, void *kpage, bool writable)
 
   pte = lookup_page (pd, upage, true);
 
-  if (pte != NULL) 
+  if (pte != NULL)
     {
       ASSERT ((*pte & PTE_P) == 0);
       *pte = pte_create_user (kpage, writable);
@@ -123,12 +123,12 @@ pagedir_set_page (uint32_t *pd, void *upage, void *kpage, bool writable)
    corresponding to that physical address, or a null pointer if
    UADDR is unmapped. */
 void *
-pagedir_get_page (uint32_t *pd, const void *uaddr) 
+pagedir_get_page (uint32_t *pd, const void *uaddr)
 {
   uint32_t *pte;
 
   ASSERT (is_user_vaddr (uaddr));
-  
+
   pte = lookup_page (pd, uaddr, false);
   if (pte != NULL && (*pte & PTE_P) != 0)
     return pte_get_page (*pte) + pg_ofs (uaddr);
@@ -141,7 +141,7 @@ pagedir_get_page (uint32_t *pd, const void *uaddr)
    bits in the page table entry are preserved.
    UPAGE need not be mapped. */
 void
-pagedir_clear_page (uint32_t *pd, void *upage) 
+pagedir_clear_page (uint32_t *pd, void *upage)
 {
   uint32_t *pte;
 
@@ -161,7 +161,7 @@ pagedir_clear_page (uint32_t *pd, void *upage)
    installed.
    Returns false if PD contains no PTE for VPAGE. */
 bool
-pagedir_is_dirty (uint32_t *pd, const void *vpage) 
+pagedir_is_dirty (uint32_t *pd, const void *vpage)
 {
   uint32_t *pte = lookup_page (pd, vpage, false);
   return pte != NULL && (*pte & PTE_D) != 0;
@@ -170,14 +170,14 @@ pagedir_is_dirty (uint32_t *pd, const void *vpage)
 /* Set the dirty bit to DIRTY in the PTE for virtual page VPAGE
    in PD. */
 void
-pagedir_set_dirty (uint32_t *pd, const void *vpage, bool dirty) 
+pagedir_set_dirty (uint32_t *pd, const void *vpage, bool dirty)
 {
   uint32_t *pte = lookup_page (pd, vpage, false);
-  if (pte != NULL) 
+  if (pte != NULL)
     {
       if (dirty)
         *pte |= PTE_D;
-      else 
+      else
         {
           *pte &= ~(uint32_t) PTE_D;
           invalidate_pagedir (pd);
@@ -190,7 +190,7 @@ pagedir_set_dirty (uint32_t *pd, const void *vpage, bool dirty)
    installed and the last time it was cleared.  Returns false if
    PD contains no PTE for VPAGE. */
 bool
-pagedir_is_accessed (uint32_t *pd, const void *vpage) 
+pagedir_is_accessed (uint32_t *pd, const void *vpage)
 {
   uint32_t *pte = lookup_page (pd, vpage, false);
   return pte != NULL && (*pte & PTE_A) != 0;
@@ -199,16 +199,16 @@ pagedir_is_accessed (uint32_t *pd, const void *vpage)
 /* Sets the accessed bit to ACCESSED in the PTE for virtual page
    VPAGE in PD. */
 void
-pagedir_set_accessed (uint32_t *pd, const void *vpage, bool accessed) 
+pagedir_set_accessed (uint32_t *pd, const void *vpage, bool accessed)
 {
   uint32_t *pte = lookup_page (pd, vpage, false);
-  if (pte != NULL) 
+  if (pte != NULL)
     {
       if (accessed)
         *pte |= PTE_A;
-      else 
+      else
         {
-          *pte &= ~(uint32_t) PTE_A; 
+          *pte &= ~(uint32_t) PTE_A;
           invalidate_pagedir (pd);
         }
     }
@@ -217,7 +217,7 @@ pagedir_set_accessed (uint32_t *pd, const void *vpage, bool accessed)
 /* Loads page directory PD into the CPU's page directory base
    register. */
 void
-pagedir_activate (uint32_t *pd) 
+pagedir_activate (uint32_t *pd)
 {
   if (pd == NULL)
     pd = init_page_dir;
@@ -232,7 +232,7 @@ pagedir_activate (uint32_t *pd)
 
 /* Returns the currently active page directory. */
 static uint32_t *
-active_pd (void) 
+active_pd (void)
 {
   /* Copy CR3, the page directory base register (PDBR), into
      `pd'.
@@ -252,12 +252,12 @@ active_pd (void)
    directory.  (If PD is not active then its entries are not in
    the TLB, so there is no need to invalidate anything.) */
 static void
-invalidate_pagedir (uint32_t *pd) 
+invalidate_pagedir (uint32_t *pd)
 {
-  if (active_pd () == pd) 
+  if (active_pd () == pd)
     {
       /* Re-activating PD clears the TLB.  See [IA32-v3a] 3.12
          "Translation Lookaside Buffers (TLBs)". */
       pagedir_activate (pd);
-    } 
+    }
 }

--- a/pintos/src/userprog/process.c
+++ b/pintos/src/userprog/process.c
@@ -28,7 +28,7 @@ static bool load (const char *cmdline, void (**eip) (void), void **esp);
    before process_execute() returns.  Returns the new process's
    thread id, or TID_ERROR if the thread cannot be created. */
 tid_t
-process_execute (const char *file_name) 
+process_execute (const char *file_name)
 {
   char *fn_copy;
   tid_t tid;
@@ -44,7 +44,7 @@ process_execute (const char *file_name)
   /* Create a new thread to execute FILE_NAME. */
   tid = thread_create (file_name, PRI_DEFAULT, start_process, fn_copy);
   if (tid == TID_ERROR)
-    palloc_free_page (fn_copy); 
+    palloc_free_page (fn_copy);
   return tid;
 }
 
@@ -66,7 +66,7 @@ start_process (void *file_name_)
 
   /* If load failed, quit. */
   palloc_free_page (file_name);
-  if (!success) 
+  if (!success)
     thread_exit ();
 
   /* Start the user process by simulating a return from an
@@ -89,7 +89,7 @@ start_process (void *file_name_)
    This function will be implemented in problem 2-2.  For now, it
    does nothing. */
 int
-process_wait (tid_t child_tid UNUSED) 
+process_wait (tid_t child_tid UNUSED)
 {
   sema_down (&temporary);
   return 0;
@@ -105,7 +105,7 @@ process_exit (void)
   /* Destroy the current process's page directory and switch back
      to the kernel-only page directory. */
   pd = cur->pagedir;
-  if (pd != NULL) 
+  if (pd != NULL)
     {
       /* Correct ordering here is crucial.  We must set
          cur->pagedir to NULL before switching page directories,
@@ -136,7 +136,7 @@ process_activate (void)
      interrupts. */
   tss_update ();
 }
-
+
 /* We load ELF binaries.  The following definitions are taken
    from the ELF specification, [ELF1], more-or-less verbatim.  */
 
@@ -211,7 +211,7 @@ static bool load_segment (struct file *file, off_t ofs, uint8_t *upage,
    and its initial stack pointer into *ESP.
    Returns true if successful, false otherwise. */
 bool
-load (const char *file_name, void (**eip) (void), void **esp) 
+load (const char *file_name, void (**eip) (void), void **esp)
 {
   struct thread *t = thread_current ();
   struct Elf32_Ehdr ehdr;
@@ -222,16 +222,16 @@ load (const char *file_name, void (**eip) (void), void **esp)
 
   /* Allocate and activate page directory. */
   t->pagedir = pagedir_create ();
-  if (t->pagedir == NULL) 
+  if (t->pagedir == NULL)
     goto done;
   process_activate ();
 
   /* Open executable file. */
   file = filesys_open (file_name);
-  if (file == NULL) 
+  if (file == NULL)
     {
       printf ("load: %s: open failed\n", file_name);
-      goto done; 
+      goto done;
     }
 
   /* Read and verify executable header. */
@@ -241,15 +241,15 @@ load (const char *file_name, void (**eip) (void), void **esp)
       || ehdr.e_machine != 3
       || ehdr.e_version != 1
       || ehdr.e_phentsize != sizeof (struct Elf32_Phdr)
-      || ehdr.e_phnum > 1024) 
+      || ehdr.e_phnum > 1024)
     {
       printf ("load: %s: error loading executable\n", file_name);
-      goto done; 
+      goto done;
     }
 
   /* Read program headers. */
   file_ofs = ehdr.e_phoff;
-  for (i = 0; i < ehdr.e_phnum; i++) 
+  for (i = 0; i < ehdr.e_phnum; i++)
     {
       struct Elf32_Phdr phdr;
 
@@ -260,7 +260,7 @@ load (const char *file_name, void (**eip) (void), void **esp)
       if (file_read (file, &phdr, sizeof phdr) != sizeof phdr)
         goto done;
       file_ofs += sizeof phdr;
-      switch (phdr.p_type) 
+      switch (phdr.p_type)
         {
         case PT_NULL:
         case PT_NOTE:
@@ -274,7 +274,7 @@ load (const char *file_name, void (**eip) (void), void **esp)
         case PT_SHLIB:
           goto done;
         case PT_LOAD:
-          if (validate_segment (&phdr, file)) 
+          if (validate_segment (&phdr, file))
             {
               bool writable = (phdr.p_flags & PF_W) != 0;
               uint32_t file_page = phdr.p_offset & ~PGMASK;
@@ -289,7 +289,7 @@ load (const char *file_name, void (**eip) (void), void **esp)
                   zero_bytes = (ROUND_UP (page_offset + phdr.p_memsz, PGSIZE)
                                 - read_bytes);
                 }
-              else 
+              else
                 {
                   /* Entirely zero.
                      Don't read anything from disk. */
@@ -320,7 +320,7 @@ load (const char *file_name, void (**eip) (void), void **esp)
   file_close (file);
   return success;
 }
-
+
 /* load() helpers. */
 
 static bool install_page (void *upage, void *kpage, bool writable);
@@ -328,24 +328,24 @@ static bool install_page (void *upage, void *kpage, bool writable);
 /* Checks whether PHDR describes a valid, loadable segment in
    FILE and returns true if so, false otherwise. */
 static bool
-validate_segment (const struct Elf32_Phdr *phdr, struct file *file) 
+validate_segment (const struct Elf32_Phdr *phdr, struct file *file)
 {
   /* p_offset and p_vaddr must have the same page offset. */
-  if ((phdr->p_offset & PGMASK) != (phdr->p_vaddr & PGMASK)) 
-    return false; 
+  if ((phdr->p_offset & PGMASK) != (phdr->p_vaddr & PGMASK))
+    return false;
 
   /* p_offset must point within FILE. */
-  if (phdr->p_offset > (Elf32_Off) file_length (file)) 
+  if (phdr->p_offset > (Elf32_Off) file_length (file))
     return false;
 
   /* p_memsz must be at least as big as p_filesz. */
-  if (phdr->p_memsz < phdr->p_filesz) 
-    return false; 
+  if (phdr->p_memsz < phdr->p_filesz)
+    return false;
 
   /* The segment must not be empty. */
   if (phdr->p_memsz == 0)
     return false;
-  
+
   /* The virtual memory region must both start and end within the
      user address space range. */
   if (!is_user_vaddr ((void *) phdr->p_vaddr))
@@ -386,14 +386,14 @@ validate_segment (const struct Elf32_Phdr *phdr, struct file *file)
    or disk read error occurs. */
 static bool
 load_segment (struct file *file, off_t ofs, uint8_t *upage,
-              uint32_t read_bytes, uint32_t zero_bytes, bool writable) 
+              uint32_t read_bytes, uint32_t zero_bytes, bool writable)
 {
   ASSERT ((read_bytes + zero_bytes) % PGSIZE == 0);
   ASSERT (pg_ofs (upage) == 0);
   ASSERT (ofs % PGSIZE == 0);
 
   file_seek (file, ofs);
-  while (read_bytes > 0 || zero_bytes > 0) 
+  while (read_bytes > 0 || zero_bytes > 0)
     {
       /* Calculate how to fill this page.
          We will read PAGE_READ_BYTES bytes from FILE
@@ -410,15 +410,15 @@ load_segment (struct file *file, off_t ofs, uint8_t *upage,
       if (file_read (file, kpage, page_read_bytes) != (int) page_read_bytes)
         {
           palloc_free_page (kpage);
-          return false; 
+          return false;
         }
       memset (kpage + page_read_bytes, 0, page_zero_bytes);
 
       /* Add the page to the process's address space. */
-      if (!install_page (upage, kpage, writable)) 
+      if (!install_page (upage, kpage, writable))
         {
           palloc_free_page (kpage);
-          return false; 
+          return false;
         }
 
       /* Advance. */
@@ -432,13 +432,13 @@ load_segment (struct file *file, off_t ofs, uint8_t *upage,
 /* Create a minimal stack by mapping a zeroed page at the top of
    user virtual memory. */
 static bool
-setup_stack (void **esp) 
+setup_stack (void **esp)
 {
   uint8_t *kpage;
   bool success = false;
 
   kpage = palloc_get_page (PAL_USER | PAL_ZERO);
-  if (kpage != NULL) 
+  if (kpage != NULL)
     {
       success = install_page (((uint8_t *) PHYS_BASE) - PGSIZE, kpage, true);
       if (success)

--- a/pintos/src/userprog/syscall.c
+++ b/pintos/src/userprog/syscall.c
@@ -7,13 +7,13 @@
 static void syscall_handler (struct intr_frame *);
 
 void
-syscall_init (void) 
+syscall_init (void)
 {
   intr_register_int (0x30, 3, INTR_ON, syscall_handler, "syscall");
 }
 
 static void
-syscall_handler (struct intr_frame *f UNUSED) 
+syscall_handler (struct intr_frame *f UNUSED)
 {
   uint32_t* args = ((uint32_t*) f->esp);
   printf("System call number: %d\n", args[0]);

--- a/pintos/src/userprog/tss.c
+++ b/pintos/src/userprog/tss.c
@@ -77,7 +77,7 @@ static struct tss *tss;
 
 /* Initializes the kernel TSS. */
 void
-tss_init (void) 
+tss_init (void)
 {
   /* Our TSS is never used in a call gate or task gate, so only a
      few fields of it are ever referenced, and those are the only
@@ -90,7 +90,7 @@ tss_init (void)
 
 /* Returns the kernel TSS. */
 struct tss *
-tss_get (void) 
+tss_get (void)
 {
   ASSERT (tss != NULL);
   return tss;
@@ -99,7 +99,7 @@ tss_get (void)
 /* Sets the ring 0 stack pointer in the TSS to point to the end
    of the thread stack. */
 void
-tss_update (void) 
+tss_update (void)
 {
   ASSERT (tss != NULL);
   tss->esp0 = (uint8_t *) thread_current () + PGSIZE;

--- a/pintos/src/utils/setitimer-helper.c
+++ b/pintos/src/utils/setitimer-helper.c
@@ -8,7 +8,7 @@
 #include <unistd.h>
 
 int
-main (int argc, char *argv[]) 
+main (int argc, char *argv[])
 {
   const char *program_name = argv[0];
   double timeout;
@@ -41,7 +41,7 @@ main (int argc, char *argv[])
   else
     fprintf (stderr, "%s: invalid timeout value \"%s\"\n",
              program_name, argv[1]);
-  
+
   execvp (argv[2], &argv[2]);
   fprintf (stderr, "%s: couldn't exec \"%s\": %s\n",
            program_name, argv[2], strerror (errno));

--- a/pintos/src/utils/squish-pty.c
+++ b/pintos/src/utils/squish-pty.c
@@ -45,7 +45,7 @@ fail_io (const char *msg, ...)
 static void
 make_noncanon (int fd, int vmin, int vtime)
 {
-  if (isatty (fd)) 
+  if (isatty (fd))
     {
       struct termios termios;
       if (tcgetattr (fd, &termios) < 0)
@@ -61,7 +61,7 @@ make_noncanon (int fd, int vmin, int vtime)
 /* Make FD non-blocking if NONBLOCKING is true,
    or blocking if NONBLOCKING is false. */
 static void
-make_nonblocking (int fd, bool nonblocking) 
+make_nonblocking (int fd, bool nonblocking)
 {
   int flags = fcntl (fd, F_GETFL);
   if (flags < 0)
@@ -91,10 +91,10 @@ handle_error (ssize_t retval, int *fd, bool fd_is_pty, const char *call)
               *fd = -1;
             }
           else
-            fail_io (call); 
+            fail_io (call);
         }
     }
-  else 
+  else
     {
       if (retval == 0)
         {
@@ -109,9 +109,9 @@ handle_error (ssize_t retval, int *fd, bool fd_is_pty, const char *call)
 /* Copies data from stdin to PTY and from PTY to stdout until no
    more data can be read or written. */
 static void
-relay (int pty, int dead_child_fd) 
+relay (int pty, int dead_child_fd)
 {
-  struct pipe 
+  struct pipe
     {
       int in, out;
       char buf[BUFSIZ];
@@ -137,7 +137,7 @@ relay (int pty, int dead_child_fd)
   pipes[0].out = pty;
   pipes[1].in = pty;
   pipes[1].out = STDOUT_FILENO;
-  
+
   while (pipes[1].in != -1)
     {
       fd_set read_fds, write_fds;
@@ -155,33 +155,33 @@ relay (int pty, int dead_child_fd)
              too eager, Bochs will throw away our input. */
           if (i == 0 && !pipes[1].active)
             continue;
-          
+
           if (p->in != -1 && p->size + p->ofs < sizeof p->buf)
             FD_SET (p->in, &read_fds);
           if (p->out != -1 && p->size > 0)
-            FD_SET (p->out, &write_fds); 
+            FD_SET (p->out, &write_fds);
         }
       FD_SET (dead_child_fd, &read_fds);
 
-      do 
+      do
         {
-          retval = select (FD_SETSIZE, &read_fds, &write_fds, NULL, NULL); 
+          retval = select (FD_SETSIZE, &read_fds, &write_fds, NULL, NULL);
         }
       while (retval < 0 && errno == EINTR);
-      if (retval < 0) 
+      if (retval < 0)
         fail_io ("select");
 
       if (FD_ISSET (dead_child_fd, &read_fds))
         break;
 
-      for (i = 0; i < 2; i++) 
+      for (i = 0; i < 2; i++)
         {
           struct pipe *p = &pipes[i];
           if (p->in != -1 && FD_ISSET (p->in, &read_fds))
             {
               ssize_t n = read (p->in, p->buf + p->ofs + p->size,
                                 sizeof p->buf - p->ofs - p->size);
-              if (n > 0) 
+              if (n > 0)
                 {
                   p->active = true;
                   p->size += n;
@@ -194,10 +194,10 @@ relay (int pty, int dead_child_fd)
               else
                 handle_error (n, &p->in, p->in == pty, "read");
             }
-          if (p->out != -1 && FD_ISSET (p->out, &write_fds)) 
+          if (p->out != -1 && FD_ISSET (p->out, &write_fds))
             {
               ssize_t n = write (p->out, p->buf + p->ofs, p->size);
-              if (n > 0) 
+              if (n > 0)
                 {
                   p->ofs += n;
                   p->size -= n;
@@ -220,7 +220,7 @@ relay (int pty, int dead_child_fd)
         ssize_t n;
 
         /* Write buffer. */
-        while (p->size > 0) 
+        while (p->size > 0)
           {
             n = write (p->out, p->buf + p->ofs, p->size);
             if (n < 0)
@@ -241,7 +241,7 @@ relay (int pty, int dead_child_fd)
 static int dead_child_fd;
 
 static void
-sigchld_handler (int signo __attribute__ ((unused))) 
+sigchld_handler (int signo __attribute__ ((unused)))
 {
   if (write (dead_child_fd, "", 1) < 0)
     _exit (1);
@@ -257,7 +257,7 @@ main (int argc __attribute__ ((unused)), char *argv[])
   int pipe_fds[2];
   struct itimerval zero_itimerval, old_itimerval;
 
-  if (argc < 2) 
+  if (argc < 2)
     {
       fprintf (stderr,
                "usage: squish-pty COMMAND [ARG]...\n"
@@ -312,11 +312,11 @@ main (int argc __attribute__ ((unused)), char *argv[])
   memset (&zero_itimerval, 0, sizeof zero_itimerval);
   if (setitimer (ITIMER_VIRTUAL, &zero_itimerval, &old_itimerval) < 0)
     fail_io ("setitimer");
-  
+
   pid = fork ();
   if (pid < 0)
     fail_io ("fork");
-  else if (pid != 0) 
+  else if (pid != 0)
     {
       /* Running in parent process. */
       int status;
@@ -333,9 +333,9 @@ main (int argc __attribute__ ((unused)), char *argv[])
           else if (WIFSIGNALED (status))
             raise (WTERMSIG (status));
         }
-      return 0; 
+      return 0;
     }
-  else 
+  else
     {
       /* Running in child process. */
       if (setitimer (ITIMER_VIRTUAL, &old_itimerval, NULL) < 0)

--- a/pintos/src/utils/squish-unix.c
+++ b/pintos/src/utils/squish-unix.c
@@ -48,7 +48,7 @@ fail_io (const char *msg, ...)
 static void
 make_noncanon (int fd, int vmin, int vtime)
 {
-  if (isatty (fd)) 
+  if (isatty (fd))
     {
       struct termios termios;
       if (tcgetattr (fd, &termios) < 0)
@@ -64,7 +64,7 @@ make_noncanon (int fd, int vmin, int vtime)
 /* Make FD non-blocking if NONBLOCKING is true,
    or blocking if NONBLOCKING is false. */
 static void
-make_nonblocking (int fd, bool nonblocking) 
+make_nonblocking (int fd, bool nonblocking)
 {
   int flags = fcntl (fd, F_GETFL);
   if (flags < 0)
@@ -96,15 +96,15 @@ handle_error (ssize_t retval, int *fd, bool fd_is_sock, const char *call)
         }
     }
   else
-    fail_io (call); 
+    fail_io (call);
 }
 
 /* Copies data from stdin to SOCK and from SOCK to stdout until no
    more data can be read or written. */
 static void
-relay (int sock) 
+relay (int sock)
 {
-  struct pipe 
+  struct pipe
     {
       int in, out;
       char buf[BUFSIZ];
@@ -131,7 +131,7 @@ relay (int sock)
   pipes[0].out = sock;
   pipes[1].in = sock;
   pipes[1].out = STDOUT_FILENO;
-  
+
   while (pipes[0].in != -1 || pipes[1].in != -1
          || (pipes[1].size && pipes[1].out != -1))
     {
@@ -151,16 +151,16 @@ relay (int sock)
              too eager, vmplayer will throw away our input. */
           if (i == 0 && !pipes[1].active)
             continue;
-          
+
           if (p->in != -1 && p->size + p->ofs < sizeof p->buf)
             FD_SET (p->in, &read_fds);
           if (p->out != -1 && p->size > 0)
-            FD_SET (p->out, &write_fds); 
+            FD_SET (p->out, &write_fds);
         }
       sigemptyset (&empty_set);
       retval = pselect (FD_SETSIZE, &read_fds, &write_fds, NULL, NULL,
                         &empty_set);
-      if (retval < 0) 
+      if (retval < 0)
         {
           if (errno == EINTR)
             {
@@ -169,12 +169,12 @@ relay (int sock)
               if (p->out == -1)
                 exit (0);
               make_nonblocking (STDOUT_FILENO, false);
-              for (;;) 
+              for (;;)
                 {
                   ssize_t n;
-                  
+
                   /* Write buffer. */
-                  while (p->size > 0) 
+                  while (p->size > 0)
                     {
                       n = write (p->out, p->buf + p->ofs, p->size);
                       if (n < 0)
@@ -191,17 +191,17 @@ relay (int sock)
                     exit (0);
                 }
             }
-          fail_io ("select"); 
+          fail_io ("select");
         }
 
-      for (i = 0; i < 2; i++) 
+      for (i = 0; i < 2; i++)
         {
           struct pipe *p = &pipes[i];
           if (p->in != -1 && FD_ISSET (p->in, &read_fds))
             {
               ssize_t n = read (p->in, p->buf + p->ofs + p->size,
                                 sizeof p->buf - p->ofs - p->size);
-              if (n > 0) 
+              if (n > 0)
                 {
                   p->active = true;
                   p->size += n;
@@ -214,10 +214,10 @@ relay (int sock)
               else if (!handle_error (n, &p->in, p->in == sock, "read"))
                 return;
             }
-          if (p->out != -1 && FD_ISSET (p->out, &write_fds)) 
+          if (p->out != -1 && FD_ISSET (p->out, &write_fds))
             {
               ssize_t n = write (p->out, p->buf + p->ofs, p->size);
-              if (n > 0) 
+              if (n > 0)
                 {
                   p->ofs += n;
                   p->size -= n;
@@ -232,7 +232,7 @@ relay (int sock)
 }
 
 static void
-sigchld_handler (int signo __attribute__ ((unused))) 
+sigchld_handler (int signo __attribute__ ((unused)))
 {
   /* Nothing to do. */
 }
@@ -245,8 +245,8 @@ main (int argc __attribute__ ((unused)), char *argv[])
   struct sockaddr_un sun;
   sigset_t sigchld_set;
   int sock;
-  
-  if (argc < 3) 
+
+  if (argc < 3)
     {
       fprintf (stderr,
                "usage: squish-unix SOCKET COMMAND [ARG]...\n"
@@ -289,15 +289,15 @@ main (int argc __attribute__ ((unused)), char *argv[])
   memset (&zero_itimerval, 0, sizeof zero_itimerval);
   if (setitimer (ITIMER_VIRTUAL, &zero_itimerval, NULL) < 0)
     fail_io ("setitimer");
-  
+
   pid = fork ();
   if (pid < 0)
     fail_io ("fork");
-  else if (pid != 0) 
+  else if (pid != 0)
     {
       /* Running in parent process. */
       make_nonblocking (sock, true);
-      for (;;) 
+      for (;;)
         {
           fd_set read_fds;
           sigset_t empty_set;
@@ -309,11 +309,11 @@ main (int argc __attribute__ ((unused)), char *argv[])
           FD_SET (sock, &read_fds);
           sigemptyset (&empty_set);
           retval = pselect (sock + 1, &read_fds, NULL, NULL, NULL, &empty_set);
-          if (retval < 0) 
+          if (retval < 0)
             {
               if (errno == EINTR)
                 break;
-              fail_io ("select"); 
+              fail_io ("select");
             }
 
           /* Accept connection. */
@@ -325,9 +325,9 @@ main (int argc __attribute__ ((unused)), char *argv[])
           relay (conn);
           close (conn);
         }
-      return 0; 
+      return 0;
     }
-  else 
+  else
     {
       /* Running in child process. */
       if (close (sock) < 0)


### PR DESCRIPTION
The pintos source had trailing whitespace all over the place. The whitespace was removed by executing the commands below on OSX while within the `group0/pintos` directory.
```
find . -name "*.h" -exec grep -l "\s\+$" {} \; | xargs sed -i '' -E 's/[[:space:]]+$//'
find . -name "*.c" -exec grep -l "\s\+$" {} \; | xargs sed -i '' -E 's/[[:space:]]+$//'
```