### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *~
 .DS_Store
 pintos/**/build
+._*


### PR DESCRIPTION
Too many groups are also adding `._.DS_Store` to their repos. Might as well ignore all dotfiles by default as well.